### PR TITLE
Use Xfixes to show and hide cursor on Linux

### DIFF
--- a/.github/workflows/continuous_integration_other.yml
+++ b/.github/workflows/continuous_integration_other.yml
@@ -28,7 +28,7 @@ jobs:
           make mac
         elif [[ "${{ runner.os }}" == 'Linux' ]]; then
           sudo apt-get update
-          sudo apt install mesa-common-dev
+          sudo apt install mesa-common-dev libxfixes-dev
           make linux
         fi
 

--- a/Makefile
+++ b/Makefile
@@ -19,4 +19,4 @@ nativemac:
 	g++ -std=c++14 -O2 --shared -g3 -o Build/libBuilderNative.so -fPIC -I Source/Native Source/Native/*.cpp Source/Native/OpenGL/*.cpp Source/Native/OpenGL/gl_load/*.c -ldl
 
 native:
-	g++ -std=c++14 -O2 --shared -g3 -o Build/libBuilderNative.so -fPIC -I Source/Native Source/Native/*.cpp Source/Native/OpenGL/*.cpp Source/Native/OpenGL/gl_load/*.c -lX11 -ldl
+	g++ -std=c++14 -O2 --shared -g3 -o Build/libBuilderNative.so -fPIC -I Source/Native Source/Native/*.cpp Source/Native/OpenGL/*.cpp Source/Native/OpenGL/gl_load/*.c -DUDB_LINUX=1 -lX11 -lXfixes -ldl

--- a/Source/Core/Actions/MouseInput.cs
+++ b/Source/Core/Actions/MouseInput.cs
@@ -55,6 +55,10 @@ namespace CodeImp.DoomBuilder.Actions
 				mouse = null;
 			}
 
+			#if MONO_WINFORMS
+			MouseInput_ShowCursor(false);
+			#endif
+
 			// We have no destructor
 			GC.SuppressFinalize(this);
 		}
@@ -67,6 +71,10 @@ namespace CodeImp.DoomBuilder.Actions
 				mouse.Dispose();
 				mouse = null;
 			}
+
+			#if MONO_WINFORMS
+			MouseInput_ShowCursor(true);
+			#endif
 		}
 
 		#endregion
@@ -113,6 +121,11 @@ namespace CodeImp.DoomBuilder.Actions
 		}
 
 		#endregion
+
+		#if MONO_WINFORMS
+		[DllImport("BuilderNative.dll", CallingConvention = CallingConvention.Cdecl)]
+		private static extern void MouseInput_ShowCursor(bool show);
+		#endif
 	}
 
 	public struct MouseState

--- a/Source/Core/Windows/MainForm.cs
+++ b/Source/Core/Windows/MainForm.cs
@@ -1263,24 +1263,6 @@ namespace CodeImp.DoomBuilder.Windows
 				Cursor.Position = display.PointToScreen(new Point(display.ClientSize.Width / 2, display.ClientSize.Height / 2)); //mxd
 				Cursor.Clip = display.RectangleToScreen(display.ClientRectangle);
 				Cursor.Hide();
-				
-				#if MONO_WINFORMS
-				// A beautiful transparent cursor, just for you mono!
-				string emptycursor =
-					"AAACAAEAICACAAAAAAAwAQAAFgAAACgAAAAgAAAAQAAAAAEAAQAAAAAAgAAAAAAAAAAAAAAAAgAA" +
-					"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" +
-					"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" +
-					"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA////////////////////////////////////////" +
-					"////////////////////////////////////////////////////////////////////////////" +
-					"//////////////////////////////////////////////////////8=";
-				using (var stream = new MemoryStream(System.Convert.FromBase64String(emptycursor)))
-				{
-					var cursor = new Cursor(stream);
-					Cursor.Current = cursor;
-					display.Cursor = cursor;
-				}
-				Application.DoEvents();
-				#endif
 			}
 		}
 
@@ -1297,11 +1279,6 @@ namespace CodeImp.DoomBuilder.Windows
 				// Release and show the mouse
 				Cursor.Clip = Rectangle.Empty;
 				Cursor.Position = display.PointToScreen(new Point(display.ClientSize.Width / 2, display.ClientSize.Height / 2));
-				#if MONO_WINFORMS
-				Cursor.Current = Cursors.Default;
-				display.Cursor = Cursors.Default;
-				Application.DoEvents();
-				#endif
 				Cursor.Show();
 			}
 		}

--- a/Source/Native/RawMouse.cpp
+++ b/Source/Native/RawMouse.cpp
@@ -172,7 +172,7 @@ extern "C"
 
 RawMouse* RawMouse_New(void* hwnd)
 {
-#ifdef WIN32
+#if defined(WIN32)
 	return new RawMouse(hwnd);
 #else
 	return nullptr;
@@ -192,6 +192,30 @@ float RawMouse_GetX(RawMouse* mouse)
 float RawMouse_GetY(RawMouse* mouse)
 {
 	return mouse->GetY();
+}
+
+#ifdef UDB_LINUX
+#include <X11/extensions/Xfixes.h>
+
+static Display *display = NULL;
+#endif
+
+void MouseInput_ShowCursor(bool show)
+{
+#ifdef UDB_LINUX
+	if (display == NULL)
+	{
+		display = XOpenDisplay(NULL);
+		if (display == NULL)
+			return;
+    }
+
+	if (show)
+		XFixesShowCursor(display, DefaultRootWindow(display));
+	else
+		XFixesHideCursor(display, DefaultRootWindow(display));
+	XSync(display, True);
+#endif
 }
 
 }

--- a/Source/Native/exports.def
+++ b/Source/Native/exports.def
@@ -50,6 +50,7 @@ EXPORTS
 	RawMouse_Delete
 	RawMouse_GetX
 	RawMouse_GetY
+	MouseInput_ShowCursor
 	Matrix_Null
 	Matrix_Identity
 	Matrix_Translation


### PR DESCRIPTION
Using an invisible cursor causes problems when other actions set the cursor back to the default. Using a common X11 extension, this small change hides and shows the cursor without otherwise changing the cursor itself, fixing these issues with minimal changes to the rest of the codebase.