### PR TITLE
Fixes a crash when pressing both mouse buttons on Linux

### DIFF
--- a/Source/Core/Actions/ActionManager.cs
+++ b/Source/Core/Actions/ActionManager.cs
@@ -506,6 +506,10 @@ namespace CodeImp.DoomBuilder.Actions
             // Update pressed keys
             if (!repeat) pressedkeys.Add(strippedkey);
 
+			if (key == 0) {
+				return false;
+			}
+
             // Add action to active list
             Action[] acts = GetActionsByKey(key);
             bool absorbed = acts.Length > 0;


### PR DESCRIPTION
Pressing both mouse buttons causes all unbound actions to run. Normally this wouldn't be a big deal but one of those actions consistently crashes UDB on my computer. I added a quick check to stop this from happening. 

Fixes https://github.com/UltimateDoomBuilder/UltimateDoomBuilder/issues/1061