### PR TITLE
Corrected angle increments to 5 degrees when using Alt+mouse to change curve angle in Curve Linedefs Mode

### DIFF
--- a/Source/Plugins/BuilderModes/Interface/CurveLinedefsOptionsPanel.Designer.cs
+++ b/Source/Plugins/BuilderModes/Interface/CurveLinedefsOptionsPanel.Designer.cs
@@ -147,7 +147,7 @@
 			// 
 			this.angle.AutoSize = false;
 			this.angle.Increment = new decimal(new int[] {
-            8,
+            5,
             0,
             0,
             0});


### PR DESCRIPTION
As discussed on the discord, this appears to be a bug, going by comments in `CurveLinedefsMode.cs` and the fact that there have been no repo changes in `CurveLinedefsOptionsPanel.designer.cs`

Likely a copy/paste of the distance.Increment value (which *should* be 8mp)