### PR TITLE
Curve Linedefs Mode: use Ctrl+Alt+RMB+Drag with Fixed Circular Curve to match angle and vertex count to 15 degree segments

### DIFF
--- a/Help/e_curvelinedefs.html
+++ b/Help/e_curvelinedefs.html
@@ -32,6 +32,22 @@
 			<td valign="top"><b>Escape</b></td>
 			<td>Discard the changes and return to the previous mode.</td>
 		</tr>
+		<tr>
+			<td valign="top"><b>Ctrl + Mousewheel</b></td>
+			<td>Increase/decrease the number of dividing vertices.</td>
+		</tr>
+		<tr>
+			<td valign="top"><b>LMB + Drag</b></td>
+			<td>Change the distance of the curve (when Fixed Circular Curve is not set).</td>
+		</tr>
+		<tr>
+			<td valign="top"><b>RMB + Drag</b></td>
+			<td>Change the angle of the curve.</td>
+		</tr>
+		<tr>
+			<td valign="top"><b>Ctrl + Alt + RMB + Drag</b></td>
+			<td>When Fixed Circlar Curve is set, increase/decrease the dividing vertices together with the angle of the curve to maintain a consistent circular curve</td>
+		</tr>
 		</table>
 	</p>
 	</div>

--- a/Source/Plugins/BuilderModes/ClassicModes/CurveLinedefsMode.cs
+++ b/Source/Plugins/BuilderModes/ClassicModes/CurveLinedefsMode.cs
@@ -496,6 +496,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 			else if(editpressed && prevoffset != 0)
 			{
 				int newangle = 0;
+				int newvertices = panel.Vertices;
 				if(panel.FixedCurve)
 				{
 					// Flip required?
@@ -513,7 +514,9 @@ namespace CodeImp.DoomBuilder.BuilderModes
 					//TODO: there surely is a way to get new angle without iteration...
 					double targetoffset = radius.GetLength() * u;
 					double prevdiff = double.MaxValue;
-					int increment = (clampvalue ? panel.AngleIncrement : 1);
+					bool clampToKeyEllipseSegments = General.Interface.CtrlState && General.Interface.AltState;
+
+					int increment = (clampToKeyEllipseSegments ? 15 : clampvalue ? panel.AngleIncrement : 1);
 					for(int i = 1; i < panel.MaximumAngle; i += increment)
 					{
 						// Calculate diameter for current angle...
@@ -530,7 +533,19 @@ namespace CodeImp.DoomBuilder.BuilderModes
 					}
 
 					// Clamp to 5 deg increments
-					if(clampvalue) newangle = (newangle / panel.AngleIncrement) * panel.AngleIncrement; 
+					if(clampvalue) newangle = (newangle / increment) * increment; 
+					
+					if(clampToKeyEllipseSegments)
+					{
+						newvertices = Math.Abs(newangle) / increment - 1;
+
+						if(newvertices < 1)
+							newvertices = 1;
+						if(newangle < 30)
+						{
+							newangle = 0;
+						}
+					}
 				}
 				else
 				{
@@ -543,7 +558,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 				}
 
 				// Set new angle without triggering the update...
-				panel.SetValues(panel.Vertices, panel.Distance, newangle, panel.FixedCurve, panel.FixedCurveOutwards);
+				panel.SetValues(newvertices, panel.Distance, newangle, panel.FixedCurve, panel.FixedCurveOutwards);
 
 				// Update hint text
 				hintlabel.Text = "Angle: " + panel.Angle;

--- a/Source/Plugins/BuilderModes/Resources/Hints.cfg
+++ b/Source/Plugins/BuilderModes/Resources/Hints.cfg
@@ -242,5 +242,6 @@ group general
 "<b>LMB-drag</b> or use <k>buildermodes_increasebevel</k> and <k>buildermodes_decreasebevel</k> to change curve depth. Hold <b>Shift</b> while dragging to change by 1 map unit" 
 "<b>RMB-drag</b> or use <k>buildermodes_rotateclockwise</k> and <k>buildermodes_rotatecounterclockwise</k> to change curve bulginess. Hold <b>Shift</b> while dragging to change by 1 degree"
 "<b>LMB+RMB-drag</b> or use <k>buildermodes_increasesubdivlevel</k> and <k>buildermodes_decreasesubdivlevel</k> to change the number of points in the curve"
+"When <b>CTRL+ALT+RMB-drag</b> When Fixed Circlar Curve is set, increase/decrease the dividing vertices together with the angle of the curve to maintain a consistent circular curve."
 "Press <k>builder_acceptmode</k> to accept"
 "Press <k>builder_cancelmode</k> or <k>builder_classicedit</k> to cancel"


### PR DESCRIPTION
Bit of a wordy title, but the rationale is that UDB snaps rotation to 15 degrees, making a 24-sided circular ellipse a sensible/useful bit of geometry.

Currently to make the curve tool respect the same geometry, it's necessary to manually select vertex counts to match values the ellipse drawing tool would have made. This is fiddly and requires a bit of mental arithmetic.

Seems to me that allowing UDB to automate that for is is part of the ethos of the editor.

Ctrl + Alt + RMB + Mouse move to use it.