### PR TITLE
Fix mouse capture when picking texture in visual mode, on Mono Winforms

### DIFF
--- a/Source/Core/Controls/ImageSelectorPanel.cs
+++ b/Source/Core/Controls/ImageSelectorPanel.cs
@@ -408,6 +408,9 @@ namespace CodeImp.DoomBuilder.Controls
 		protected override void OnMouseDoubleClick(MouseEventArgs e)
 		{
 			base.OnMouseDoubleClick(e);
+			//TODO: testing this on Windows, it looks like General.Interface.CtrlState and 
+			//  General.Interface.ShiftState are always false, because as the main window
+			//  doesn't have focus and won't update these states
 			if(General.Interface.CtrlState || General.Interface.ShiftState || selection.Count != 1)
 				return;
 

--- a/Source/Core/Windows/MainForm.cs
+++ b/Source/Core/Windows/MainForm.cs
@@ -4172,14 +4172,20 @@ namespace CodeImp.DoomBuilder.Windows
 		// Returns the new texture name or the same texture name when cancelled
 		public string BrowseTexture(IWin32Window owner, string initialvalue)
 		{
-			return TextureBrowserForm.Browse(owner, initialvalue, false);//mxd
+			BreakExclusiveMouseInput();
+			string tex = TextureBrowserForm.Browse(owner, initialvalue, false);//mxd
+			ResumeExclusiveMouseInput();
+			return tex;
 		}
 
 		// This browses for a flat
 		// Returns the new flat name or the same flat name when cancelled
 		public string BrowseFlat(IWin32Window owner, string initialvalue)
 		{
-			return TextureBrowserForm.Browse(owner, initialvalue, true); //mxd. was FlatBrowserForm
+			BreakExclusiveMouseInput();
+			string tex = TextureBrowserForm.Browse(owner, initialvalue, true); //mxd. was FlatBrowserForm
+			ResumeExclusiveMouseInput();
+			return tex;
 		}
 		
 		// This browses the lindef types

--- a/Source/Core/Windows/MainForm.cs
+++ b/Source/Core/Windows/MainForm.cs
@@ -4172,9 +4172,20 @@ namespace CodeImp.DoomBuilder.Windows
 		// Returns the new texture name or the same texture name when cancelled
 		public string BrowseTexture(IWin32Window owner, string initialvalue)
 		{
+
+			DisableProcessing();
+			#if MONO_WINFORMS
+			//Mono's Winforms treat dialogs a little differently
+			//  they don't implicitly take focus from the parent window
+			//  and keyboard input from focus window isn't reset when the dialog takes focus
 			BreakExclusiveMouseInput();
+			ReleaseAllKeys();
+			#endif
 			string tex = TextureBrowserForm.Browse(owner, initialvalue, false);//mxd
+			#if MONO_WINFORMS
 			ResumeExclusiveMouseInput();
+			#endif
+			EnableProcessing();
 			return tex;
 		}
 
@@ -4182,9 +4193,19 @@ namespace CodeImp.DoomBuilder.Windows
 		// Returns the new flat name or the same flat name when cancelled
 		public string BrowseFlat(IWin32Window owner, string initialvalue)
 		{
+			DisableProcessing();
+			#if MONO_WINFORMS
+			//Mono's Winforms treat dialogs a little differently
+			//  they don't implicitly take focus from the parent window
+			//  and keyboard input from focus window isn't reset when the dialog takes focus
 			BreakExclusiveMouseInput();
+			ReleaseAllKeys();
+			#endif
 			string tex = TextureBrowserForm.Browse(owner, initialvalue, true); //mxd. was FlatBrowserForm
+			#if MONO_WINFORMS
 			ResumeExclusiveMouseInput();
+			#endif
+			EnableProcessing();
 			return tex;
 		}
 		


### PR DESCRIPTION
* Fixed bug in Visual Mode, when running with Mono Forms, using Ctrl+RMB to open texture picker directly doesn't suspend the mouse-capturing mode.
* Fixed bug where the double-click behaviour didn't work after opening the texture picker this way
This has also been tested on Windows .NET Framework