### PR TITLE
Render "AddShaded" render style as additive to better match in-game appearance

### DIFF
--- a/Source/Plugins/BuilderModes/VisualModes/BaseVisualThing.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/BaseVisualThing.cs
@@ -124,7 +124,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 						renderstyle = Thing.Fields.GetValue("renderstyle", renderstyle).ToLowerInvariant();
 					}
 
-					if((renderstyle == "add" || renderstyle == "translucent" || renderstyle == "subtract" || renderstyle == "translucentstencil") 
+					if((renderstyle == "add" || renderstyle == "translucent" || renderstyle == "subtract" || renderstyle == "translucentstencil" || renderstyle == "addshaded") 
 						&& Thing.Fields.ContainsKey("alpha"))
 					{
 						alpha = (byte)(General.Clamp(Thing.Fields.GetValue("alpha", info.Alpha), 0.0, 1.0) * 255.0);
@@ -175,6 +175,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 
 					case "add":
                     case "addstencil":
+					case "addshaded":
 						RenderPass = RenderPass.Additive;
 						break;
 


### PR DESCRIPTION
In 3D mode, things with the AddShaded renderstyle look like this:
![image](https://github.com/UltimateDoomBuilder/UltimateDoomBuilder/assets/3321682/6c4e648b-2a0a-4f02-8116-aee343a74012)

But in-game they look like this:
![image](https://github.com/UltimateDoomBuilder/UltimateDoomBuilder/assets/3321682/eee64569-50b2-45c1-a71e-80699e57f182)

Making the AddShaded renderstyle render as additive makes 3D mode a lot less of a visual mess, even though it still does not tint it.