### PR TITLE
Add more sizes to the image browser for better high DPI usability

### DIFF
--- a/Source/Core/Controls/ImageBrowserControl.Designer.cs
+++ b/Source/Core/Controls/ImageBrowserControl.Designer.cs
@@ -173,7 +173,9 @@ namespace CodeImp.DoomBuilder.Controls
             "96",
             "128",
             "192",
-            "256"});
+            "256",
+			"384",
+			"512"});
 			this.sizecombo.Location = new System.Drawing.Point(43, 32);
 			this.sizecombo.Margin = new System.Windows.Forms.Padding(3, 3, 6, 3);
 			this.sizecombo.Name = "sizecombo";


### PR DESCRIPTION
Textures in the texture browser can look tiny on high DPI/high resolution screens.

![image](https://github.com/UltimateDoomBuilder/UltimateDoomBuilder/assets/3321682/54aae06b-c3f7-4dd9-8413-bd0b7f7dc663)

This adds a 384 and 512 size to the image browser to aid in choosing the right texture.