### PR TITLE
Fixed a crash when adding opening the dialog to add a directory resource on Mono Winforms

### DIFF
--- a/Source/Core/Controls/FolderSelectDialog.cs
+++ b/Source/Core/Controls/FolderSelectDialog.cs
@@ -283,6 +283,7 @@ namespace CodeImp.DoomBuilder.Controls
         {
             bool flag = false;
 
+#if !MONO_WINFORMS
             if (Environment.OSVersion.Version.Major >= 6)
             {
                 var r = new Reflector("System.Windows.Forms");
@@ -313,6 +314,7 @@ namespace CodeImp.DoomBuilder.Controls
             }
             else
             {
+#endif
                 var fbd = new FolderBrowserDialog();
                 fbd.Description = this.Title;
                 fbd.SelectedPath = this.InitialDirectory;
@@ -320,7 +322,9 @@ namespace CodeImp.DoomBuilder.Controls
                 if (fbd.ShowDialog(new WindowWrapper(hWndOwner)) != DialogResult.OK) return false;
                 ofd.FileName = fbd.SelectedPath;
                 flag = true;
+#if !MONO_WINFORMS
             }
+#endif
 
             return flag;
         }


### PR DESCRIPTION
The code to add a nicer folder browser dialog breaks on Winforms. I went for the easier option of using the old-style folder browser dialog  to fix it.