### PR TITLE
Update DSDADoom_linedefs.cfg for 0.28

### DIFF
--- a/Build/Configurations/Includes/DSDADoom_linedefs.cfg
+++ b/Build/Configurations/Includes/DSDADoom_linedefs.cfg
@@ -2699,3 +2699,49 @@ colormap
     }
   }
 }
+
+music
+{
+  title = "Music";
+
+  2703
+  {
+    title = "Music Change Song";
+    id = "Music_ChangeSong";
+
+    arg0
+    {
+      title = "(switch to string)";
+      str = true;
+      titlestr = "Song";
+    }
+
+    arg1
+    {
+      title = "Local";
+      type = 11;
+      enum = "noyes";
+    }
+
+    arg2
+    {
+      title = "Loop";
+      type = 11;
+      enum = "noyes";
+      default = 1;
+    }
+  }
+
+  2704
+  {
+    title = "Music Stop";
+    id = "Music_Stop";
+
+    arg0
+    {
+      title = "Local";
+      type = 11;
+      enum = "noyes";
+    }
+  }
+}


### PR DESCRIPTION
The next version of dsda-doom, v0.28, will be released at the end of the week. There are a couple new line specials for changing the music (as an alternative to MUSINFO). This PR adds the new lines to the linedefs file for the dsda-doom config.