### PR TITLE
Map Analysis texture error checkers consider sky transfer linedef specials

### DIFF
--- a/Build/Configurations/Includes/Boom_linedefs.cfg
+++ b/Build/Configurations/Includes/Boom_linedefs.cfg
@@ -958,11 +958,21 @@ transfer
 	{
 		title = "Transfer Sky Texture to Tagged Sectors";
 		prefix = "";
+		
+		errorchecker
+		{
+			requiresuppertexture = true;
+		}
 	}
 	
 	272
 	{
 		title = "Transfer Sky Texture to Tagged Sectors (flipped)";
 		prefix = "";
+		
+		errorchecker
+		{
+			requiresuppertexture = true;
+		}
 	}
 }

--- a/Source/Core/Config/LinedefActionInfo.cs
+++ b/Source/Core/Config/LinedefActionInfo.cs
@@ -31,6 +31,7 @@ namespace CodeImp.DoomBuilder.Config
 		public bool IgnoreUpperTexture;
 		public bool IgnoreMiddleTexture;
 		public bool IgnoreLowerTexture;
+		public bool RequiresUpperTexture;
 		public bool FloorLowerToLowest;
 		public bool FloorRaiseToNextHigher;
 		public bool FloorRaiseToHighest;
@@ -117,6 +118,7 @@ namespace CodeImp.DoomBuilder.Config
 			this.errorcheckerexemptions.IgnoreUpperTexture = cfg.ReadSetting(actionsetting + ".errorchecker.ignoreuppertexture", false);
 			this.errorcheckerexemptions.IgnoreMiddleTexture = cfg.ReadSetting(actionsetting + ".errorchecker.ignoremiddletexture", false);
 			this.errorcheckerexemptions.IgnoreLowerTexture = cfg.ReadSetting(actionsetting + ".errorchecker.ignorelowertexture", false);
+			this.errorcheckerexemptions.RequiresUpperTexture = cfg.ReadSetting(actionsetting + ".errorchecker.requiresuppertexture", false);
 			this.errorcheckerexemptions.FloorLowerToLowest = cfg.ReadSetting(actionsetting + ".errorchecker.floorlowertolowest", false);
 			this.errorcheckerexemptions.FloorRaiseToNextHigher = cfg.ReadSetting(actionsetting + ".errorchecker.floorraisetonexthigher", false);
 			this.errorcheckerexemptions.FloorRaiseToHighest = cfg.ReadSetting(actionsetting + ".errorchecker.floorraisetohighest", false);

--- a/Source/Core/Map/Linedef.cs
+++ b/Source/Core/Map/Linedef.cs
@@ -802,6 +802,21 @@ namespace CodeImp.DoomBuilder.Map
 		
 		#region ================== Methods
 
+		// Determine if this line defines the sky upper texture transferred to a sector.
+		public bool HasSkyTransfer()
+		{
+			return HasSkyTransferStaticInit() ||
+				General.Map.Config.GetLinedefActionInfo(Action).ErrorCheckerExemptions.RequiresUpperTexture;
+		}
+
+		// Determine if this line uses Static_Init that mimics MBF's sky transfer linedef specials.
+		// This also enables an optional lower texture to be shown during a lightning weather effect.
+		public bool HasSkyTransferStaticInit()
+		{
+			return General.Map.Config.GetLinedefActionInfo(Action).Id.ToLowerInvariant() == "static_init" &&
+				Args[1] == 255;
+		}
+
 		// Determine if this line and another line are associated by action and tag.
 		public bool IsAssociatedWith(Linedef ld)
 		{

--- a/Source/Plugins/BuilderModes/ErrorChecks/CheckMissingTextures.cs
+++ b/Source/Plugins/BuilderModes/ErrorChecks/CheckMissingTextures.cs
@@ -60,7 +60,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 				// positive if the sector on the other side has the ceiling
 				// set to be sky
 				if (sd.LongHighTexture == MapSet.EmptyLongName) {
-					if (sd.HighRequired())
+					if (sd.HighRequired() || sd.Line.HasSkyTransfer())
 					{
 						if (sd.Line.Action == 181 && sd.Line.Args[1] > 0) continue; //mxd. Ceiling slopes doesn't require upper texture
 

--- a/Source/Plugins/BuilderModes/ErrorChecks/CheckUnusedTextures.cs
+++ b/Source/Plugins/BuilderModes/ErrorChecks/CheckUnusedTextures.cs
@@ -39,7 +39,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 			foreach(Sidedef sd in General.Map.Map.Sidedefs)
 			{
 				// Check upper texture
-				if(!sd.HighRequired() && sd.LongHighTexture != MapSet.EmptyLongName)
+				if(!(sd.HighRequired() || sd.Line.HasSkyTransfer()) && sd.LongHighTexture != MapSet.EmptyLongName)
 				{
 					if (sd.Other == null)
 						SubmitResult(new ResultUnusedTexture(sd, SidedefPart.Upper));
@@ -78,7 +78,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 				}
 
 				// Check lower texture
-				if(!sd.LowRequired() && sd.LongLowTexture != MapSet.EmptyLongName)
+				if(!(sd.LowRequired() || sd.Line.HasSkyTransferStaticInit()) && sd.LongLowTexture != MapSet.EmptyLongName)
 				{
 					if (sd.Other == null)
 						SubmitResult(new ResultUnusedTexture(sd, SidedefPart.Lower));


### PR DESCRIPTION
1. https://soulsphere.org/projects/boomref/mbfedit.html
   
   > Every sector with F_SKY1 floor or ceiling ... will use a sky texture based on the upper texture of the first sidedef in the 271 or 272 linedef.
2. https://zdoom.org/wiki/Static_Init
   
   > Uses the line's upper texture as the sky in any tagged sectors... The line's lower texture, if set and of the same dimensions as the upper texture, will be used during lightning flashes.

---

Adjust error check options:

1. "Check missing textures" will warn about a missing sky upper texture.
2. "Check unused textures" doesn't warn about the upper texture ("Boom"/ZDoom) or the optional lower texture (ZDoom-only)

The `Static_Init()` linedef special requires `arg1 = 255` for sky transfers so it's difficult to squeeze that `errorchecker` metadata context into the configuration files. I see class `CheckMissingTextures` hardcoding ZDoom/Eternity slope checks `sd.Line.Action == 181` so I don't feel bad doing the same.