### PR TITLE
Map Analysis missing texture errors not reported due to hardcoded ZDoom `Plane_Align`

### DIFF
--- a/Source/Core/Map/Linedef.cs
+++ b/Source/Core/Map/Linedef.cs
@@ -802,6 +802,12 @@ namespace CodeImp.DoomBuilder.Map
 		
 		#region ================== Methods
 
+		// Plane Align (181) (see http://zdoom.org/wiki/Plane_Align
+		public bool HasActionPlaneAlign()
+		{
+			return Action > 0 && General.Map.Config.GetLinedefActionInfo(Action).Id.ToLowerInvariant() == "plane_align";
+		}
+
 		// Determine if this line and another line are associated by action and tag.
 		public bool IsAssociatedWith(Linedef ld)
 		{

--- a/Source/Core/Map/Sector.cs
+++ b/Source/Core/Map/Sector.cs
@@ -707,7 +707,7 @@ namespace CodeImp.DoomBuilder.Map
 			foreach(Sidedef side in s.sidedefs)
 			{
 				// Carbon copy of EffectLineSlope class here...
-				if(side.Line.Action == 181 && ((side.Line.Args[0] == 1 && side == side.Line.Front) || side.Line.Args[0] == 2) && side.Other != null)
+				if(side.Line.HasActionPlaneAlign() && ((side.Line.Args[0] == 1 && side == side.Line.Front) || side.Line.Args[0] == 2) && side.Other != null)
 				{
 					Linedef l = side.Line;
 					
@@ -787,7 +787,7 @@ namespace CodeImp.DoomBuilder.Map
 			foreach(Sidedef side in s.sidedefs) 
 			{
 				// Carbon copy of EffectLineSlope class here...
-				if(side.Line.Action == 181 && ((side.Line.Args[1] == 1 && side == side.Line.Front) || side.Line.Args[1] == 2) && side.Other != null) 
+				if(side.Line.HasActionPlaneAlign() && ((side.Line.Args[1] == 1 && side == side.Line.Front) || side.Line.Args[1] == 2) && side.Other != null) 
 				{
 					Linedef l = side.Line;
 

--- a/Source/Plugins/BuilderModes/ErrorChecks/CheckMissingTextures.cs
+++ b/Source/Plugins/BuilderModes/ErrorChecks/CheckMissingTextures.cs
@@ -62,7 +62,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 				if (sd.LongHighTexture == MapSet.EmptyLongName) {
 					if (sd.HighRequired())
 					{
-						if (sd.Line.Action == 181 && sd.Line.Args[1] > 0) continue; //mxd. Ceiling slopes doesn't require upper texture
+						if (sd.Line.HasActionPlaneAlign() && sd.Line.Args[1] > 0) continue; //mxd. Ceiling slopes doesn't require upper texture
 
 						SubmitResult(new ResultMissingTexture(sd, SidedefPart.Upper));
 					}
@@ -109,7 +109,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 				{
 					if (sd.LowRequired())
 					{
-						if (sd.Line.Action == 181 && sd.Line.Args[0] > 0) continue; //mxd. Floor slopes doesn't require lower texture
+						if (sd.Line.HasActionPlaneAlign() && sd.Line.Args[0] > 0) continue; //mxd. Floor slopes doesn't require lower texture
 
 						SubmitResult(new ResultMissingTexture(sd, SidedefPart.Lower));
 					}


### PR DESCRIPTION
From a comment in https://github.com/UltimateDoomBuilder/UltimateDoomBuilder/pull/1142, hardcoded ZDoom `sd.Line.Action == 181` checks may cause cause missing textures to not be reported. Two other game configurations share the same linedef special:

* Boom - 181 - SR Lift Perpetual Lowest and Highest Floors
* Strife - 181 - S1 Floor Raise 512 match adjacent text/type

Add predicate `Linedef#HasActionPlaneAlign()` to check the configuration file defining `id = 'Plane_Align'`, which is the case for ZDoom & Eternity Engine.

---

Class `BaseVisualMode` still has some `Line.Action == 181` & `Line.Action != 181` hardcoded references that I've leave alone since those codepaths are in slope rendering code not covered by Boom or Strife configs.