### PR TITLE
Allow script configuration autoloading through command line arguments

### DIFF
--- a/Source/Core/General/General.cs
+++ b/Source/Core/General/General.cs
@@ -227,6 +227,7 @@ namespace CodeImp.DoomBuilder
 		private static string autoloadfile;
 		private static string autoloadmap;
 		private static string autoloadconfig;
+		private static string autoloadscriptconfig;
 		private static bool autoloadstrictpatches;
 		private static DataLocationList autoloadresources;
 		private static bool delaymainwindow;
@@ -279,6 +280,7 @@ namespace CodeImp.DoomBuilder
 		public static string AutoLoadFile { get { return autoloadfile; } }
 		public static string AutoLoadMap { get { return autoloadmap; } }
 		public static string AutoLoadConfig { get { return autoloadconfig; } }
+		public static string AutoLoadScriptConfig { get { return autoloadscriptconfig; } }
 		public static bool AutoLoadStrictPatches { get { return autoloadstrictpatches; } }
 		public static DataLocationList AutoLoadResources { get { return new DataLocationList(autoloadresources); } }
 		public static bool DelayMainWindow { get { return delaymainwindow; } }
@@ -880,6 +882,12 @@ namespace CodeImp.DoomBuilder
 				{
 					// Store next arg as config filename information
 					autoloadconfig = argslist.Dequeue();
+				}
+				// Script config? (picks the compiler configuration to use)
+				else if (string.Compare(curarg, "-SCRIPTCONFIG", true) == 0)
+				{
+					// Store next arg as the script configuration name, being the configuration's file name.
+					autoloadscriptconfig = argslist.Dequeue().ToLowerInvariant();
 				}
 				// Strict patches rules?
 				else if(string.Compare(curarg, "-STRICTPATCHES", true) == 0)

--- a/Source/Core/Windows/MainForm.cs
+++ b/Source/Core/Windows/MainForm.cs
@@ -560,6 +560,16 @@ namespace CodeImp.DoomBuilder.Windows
 					//mxd. Get proper configuration file
 					bool longtexturenamessupported = false;
 					string configfile = null;
+					string compiler = null;
+
+					// Set the script type of the map if provided.
+					if (General.AutoLoadScriptConfig != null)
+					{
+						if(General.CompiledScriptConfigs.ContainsKey(General.AutoLoadScriptConfig))
+						{
+							compiler = General.AutoLoadScriptConfig;
+						}
+					}
 
 					// Make sure the config file exists
 					if(General.GetConfigurationInfo(General.AutoLoadConfig) != null)
@@ -588,6 +598,11 @@ namespace CodeImp.DoomBuilder.Windows
 					
 					// Set configuration file (constructor already does this, but we want this info from the cmd args if possible)
 					options.ConfigFile = configfile;
+
+					if (compiler != null)
+					{
+						options.ScriptCompiler = compiler;
+					}
 				}
 				else
 				{


### PR DESCRIPTION
It is currently not possible to specify the compiler in any way when auto loading maps through the command line.
This PR adds the ability to do so by providing the configuration file name.
The code will validate the entry using `General.CompiledScriptConfigs` and assing it to the map's options when valid.

Key: `scriptconfig`
Value: The name of the configuration file to use