### PR TITLE
don't create a new tag blacklist when duplicating 3DFloor geomtry, ...

### DIFF
--- a/Source/Plugins/3DFloorMode/ThreeDFloorMode.cs
+++ b/Source/Plugins/3DFloorMode/ThreeDFloorMode.cs
@@ -1683,7 +1683,7 @@ namespace CodeImp.DoomBuilder.ThreeDFloorMode
 				int newtag;
 				int oldtag = tdf.UDMFTag;
 
-				if(!tdf.CreateGeometry(new List<int>(), drawnvertices, tdf.LinedefProperties, tdf.SectorProperties, true, out newtag))
+				if(!tdf.CreateGeometry(tagblacklist, drawnvertices, tdf.LinedefProperties, tdf.SectorProperties, true, out newtag))
 				{
 					// No need to show a warning here, that was already done by CreateGeometry
 					General.Map.UndoRedo.WithdrawUndo();


### PR DESCRIPTION
When duplicating a selection containing multiple 3D floors with multiple slopes, this collapses all selected geometry to one new tag (the new tag went into a new List which is then discarded). Since now they all share one tag, they share one slope, so the new copy is broken. Due to mutate-in-place, then copy, the mutate-original-back mechanic, it also ruins the original geometry as well as the copy. Also it does this in a way that bypasses undo, so the only way to get out of the situation is to reload the map and start over.