### PR TITLE
Fix VPO native library build and loading on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ builder:
 	chmod +x Build/builder
 
 nativemac:
-	g++ -std=c++14 -O2 --shared -g3 -o Build/libBuilderNative.so -fPIC -I Source/Native Source/Native/*.cpp Source/Native/OpenGL/*.cpp Source/Native/OpenGL/gl_load/*.c -ldl
+	g++ -std=c++14 -O2 --shared -g3 -o Build/libBuilderNative.so -fPIC -I Source/Native Source/Native/*.cpp Source/Native/OpenGL/*.cpp Source/Native/OpenGL/gl_load/*.c Source/Native/VPO/*.cpp -ldl
 
 native:
-	g++ -std=c++14 -O2 --shared -g3 -o Build/libBuilderNative.so -fPIC -I Source/Native Source/Native/*.cpp Source/Native/OpenGL/*.cpp Source/Native/OpenGL/gl_load/*.c -DUDB_LINUX=1 -lX11 -lXfixes -ldl
+	g++ -std=c++14 -O2 --shared -g3 -o Build/libBuilderNative.so -fPIC -I Source/Native Source/Native/*.cpp Source/Native/OpenGL/*.cpp Source/Native/OpenGL/gl_load/*.c Source/Native/VPO/*.cpp -DUDB_LINUX=1 -lX11 -lXfixes -ldl

--- a/Source/Native/VPO/vpo_api.h
+++ b/Source/Native/VPO/vpo_api.h
@@ -21,6 +21,10 @@
 #ifndef __VPO_API_H__
 #define __VPO_API_H__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef void* VPOContext;
 
 VPOContext VPO_NewContext();
@@ -97,6 +101,10 @@ int VPO_TestSpot(VPOContext ctx,
                  int *num_drawsegs,
                  int *num_openings,
                  int *num_solidsegs);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif  /* __VPO_API_H__ */
 

--- a/builder.sh
+++ b/builder.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 cd "$(dirname "$0")"
+export LD_LIBRARY_PATH="$PWD:$LD_LIBRARY_PATH"
 mono Builder.exe

--- a/flatpak/io.github.ultimatedoombuilder.ultimatedoombuilder.yml
+++ b/flatpak/io.github.ultimatedoombuilder.ultimatedoombuilder.yml
@@ -27,7 +27,7 @@ modules:
     buildsystem: simple
     build-commands:
       - mkdir -p /app/lib
-      - g++ -std=c++14 -O2 --shared -g3 -o /app/lib/libBuilderNative.so -fPIC -I Source/Native Source/Native/*.cpp Source/Native/OpenGL/*.cpp Source/Native/OpenGL/gl_load/*.c -DUDB_LINUX=1 -lX11 -lXfixes -ldl
+      - g++ -std=c++14 -O2 --shared -g3 -o /app/lib/libBuilderNative.so -fPIC -I Source/Native Source/Native/*.cpp Source/Native/OpenGL/*.cpp Source/Native/OpenGL/gl_load/*.c Source/Native/VPO/*.cpp -DUDB_LINUX=1 -lX11 -lXfixes -ldl
     sources:
       - type: dir
         path: ..


### PR DESCRIPTION
Closes #1097 

This fixes emitted symbols and allows plugins to locate the native library.