### PR TITLE
Add Select Opposite Side action in Visual Mode

### DIFF
--- a/Source/Plugins/BuilderModes/Resources/Actions.cfg
+++ b/Source/Plugins/BuilderModes/Resources/Actions.cfg
@@ -1573,3 +1573,14 @@ changemapelementindex
 	allowmouse = true;
 	allowscroll = false;
 }
+
+selectoppositeside
+{
+	title = "Select Opposite Side";
+	category = "visual";
+	description = "Selects the opposite sidedef, sector surface or 3D floor surface.";
+	allowkeys = true;
+	allowmouse = true;
+	allowscroll = false;
+	default = 79;
+}

--- a/Source/Plugins/BuilderModes/VisualModes/BaseVisualMode.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/BaseVisualMode.cs
@@ -4816,6 +4816,35 @@ namespace CodeImp.DoomBuilder.BuilderModes
 			}
 		}
 
+		[BeginAction("selectoppositeside")]
+		public void SelectOppositeSide()
+		{
+			foreach (var o in selectedobjects.ToList())
+			{
+				IVisualEventReceiver otherObject = null;
+
+				if (o is VisualFloor floor && floor.ExtraFloor == null)
+					otherObject = floor.Sector.Ceiling;
+				else if (o is VisualCeiling ceiling && ceiling.ExtraFloor == null)
+					otherObject = ceiling.Sector.Floor;
+				else if (o is VisualFloor extraFloor)
+					otherObject = extraFloor.Sector.ExtraCeilings.Find(ec => ec.ExtraFloor == extraFloor.ExtraFloor);
+				else if (o is VisualCeiling extraCeiling)
+					otherObject = extraCeiling.Sector.ExtraFloors.Find(ef => ef.ExtraFloor == extraCeiling.ExtraFloor);
+				else if (o is VisualMiddleDouble side)
+				{
+					BaseVisualSector otherSector = (BaseVisualSector)GetVisualSector(side.Sidedef.Other.Sector);
+					otherObject = otherSector.GetSidedefParts(side.Sidedef.Other).middledouble;
+				}
+
+				if (otherObject != null && !otherObject.Selected)
+				{
+					otherObject.OnSelectBegin();
+					otherObject.OnSelectEnd();
+				}
+			}
+		}
+
 		#endregion
 
 		#region ================== Texture Alignment


### PR DESCRIPTION
This adds a new Visual Mode action, `Select Opposite Side`, which selects the opposite surface for all selected sectors (floor/ceiling), 3D floor (top/bottom) and sidedefs (other side).

The default keybind is O.