### PR TITLE
Visual mode groups

### DIFF
--- a/Source/Core/Builder.csproj
+++ b/Source/Core/Builder.csproj
@@ -246,6 +246,7 @@
     <Compile Include="Dehacked\DehackedThing.cs" />
     <Compile Include="General\AutoSaver.cs" />
     <Compile Include="General\Hasher.cs" />
+    <Compile Include="General\MultiDictionary.cs" />
     <Compile Include="General\SHA256Hash.cs" />
     <Compile Include="General\ToastManager.cs" />
     <Compile Include="GZBuilder\Models\GZModel.cs" />

--- a/Source/Core/Builder.csproj
+++ b/Source/Core/Builder.csproj
@@ -258,6 +258,7 @@
     <Compile Include="GZBuilder\Models\MD3ModelLoader.cs" />
     <Compile Include="GZBuilder\Models\OBJModelLoader.cs" />
     <Compile Include="GZBuilder\Models\ModelLoadResult.cs" />
+    <Compile Include="Map\MapElement3D.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>

--- a/Source/Core/BuilderMono.csproj
+++ b/Source/Core/BuilderMono.csproj
@@ -361,6 +361,7 @@
     <Compile Include="IO\UniversalStreamReader.cs" />
     <Compile Include="IO\UniversalStreamWriter.cs" />
     <Compile Include="Map\MapElement.cs" />
+    <Compile Include="Map\MapElement3D.cs" />
     <Compile Include="Map\SelectableElement.cs" />
     <Compile Include="Map\UniFields.cs" />
     <Compile Include="Map\UniValue.cs" />

--- a/Source/Core/BuilderMono.csproj
+++ b/Source/Core/BuilderMono.csproj
@@ -238,6 +238,7 @@
     <Compile Include="Data\ImageLoadState.cs" />
     <Compile Include="General\AutoSaver.cs" />
     <Compile Include="General\Hasher.cs" />
+    <Compile Include="General\MultiDictionary.cs" />
     <Compile Include="General\SHA256Hash.cs" />
     <Compile Include="General\ToastManager.cs" />
     <Compile Include="GZBuilder\Models\GZModel.cs" />

--- a/Source/Core/Config/LinedefActionInfo.cs
+++ b/Source/Core/Config/LinedefActionInfo.cs
@@ -65,6 +65,7 @@ namespace CodeImp.DoomBuilder.Config
 		private readonly bool linetolinetag;
 		private readonly bool linetolinesameaction;
 		private readonly ErrorCheckerExemptions errorcheckerexemptions;
+		private readonly bool isextrafloor;
 		
 		#endregion
 
@@ -84,6 +85,7 @@ namespace CodeImp.DoomBuilder.Config
 		public bool LineToLineTag { get { return linetolinetag; } }
 		public bool LineToLineSameAction { get { return linetolinesameaction; } }
 		public ErrorCheckerExemptions ErrorCheckerExemptions { get { return errorcheckerexemptions; } }
+		public bool IsExtraFloor { get { return isextrafloor; } }
 
 		#endregion
 
@@ -122,6 +124,8 @@ namespace CodeImp.DoomBuilder.Config
 			this.errorcheckerexemptions.FloorLowerToLowest = cfg.ReadSetting(actionsetting + ".errorchecker.floorlowertolowest", false);
 			this.errorcheckerexemptions.FloorRaiseToNextHigher = cfg.ReadSetting(actionsetting + ".errorchecker.floorraisetonexthigher", false);
 			this.errorcheckerexemptions.FloorRaiseToHighest = cfg.ReadSetting(actionsetting + ".errorchecker.floorraisetohighest", false);
+
+			isextrafloor = (id == "Sector_Set3dFloor" || id.StartsWith("srb2_fof"));
 
 			// Read the args
 			for (int i = 0; i < Linedef.NUM_ARGS; i++)

--- a/Source/Core/General/MapManager.cs
+++ b/Source/Core/General/MapManager.cs
@@ -465,6 +465,8 @@ namespace CodeImp.DoomBuilder
 			//mxd. Restore selection groups
 			options.ReadSelectionGroups();
 
+			options.ReadGroups3D();
+
 			// Bind any methods
 			General.Actions.BindMethods(this);
 
@@ -559,6 +561,8 @@ namespace CodeImp.DoomBuilder
 
 			// Restore selection groups
 			options.ReadSelectionGroups();
+
+			options.ReadGroups3D();
 
 			if(General.Editing.Mode != null)
 			{

--- a/Source/Core/General/MultiDictionary.cs
+++ b/Source/Core/General/MultiDictionary.cs
@@ -1,0 +1,43 @@
+﻿using System.Collections.Generic;
+
+namespace CodeImp.DoomBuilder
+{
+	public class MultiDictionary<TKey, TValue>
+	{
+		protected readonly Dictionary<TKey, List<TValue>> dict = new Dictionary<TKey, List<TValue>>();
+
+		public List<TValue> this[TKey key] => dict[key];
+		public bool ContainsKey(TKey key) => dict.ContainsKey(key);
+
+		public bool Add(TKey key, TValue value)
+		{
+			List<TValue> list;
+
+			if (!dict.TryGetValue(key, out list))
+			{
+				list = new List<TValue>();
+				dict[key] = list;
+			}
+
+			list.Add(value);
+
+			return true;
+		}
+
+		public bool Remove(TKey key, TValue value)
+		{
+			List<TValue> list;
+
+			if (!dict.TryGetValue(key, out list)) return false;
+			if (!list.Remove(value)) return false;
+			if (list.Count == 0)
+				dict.Remove(key);
+			return true;
+		}
+
+		public void Clear()
+		{
+			dict.Clear();
+		}
+	}
+}

--- a/Source/Core/Map/MapElement3D.cs
+++ b/Source/Core/Map/MapElement3D.cs
@@ -16,11 +16,8 @@
 
 #region ================== Namespaces
 
-using System;
-using ScintillaNET;
 using System.Collections.Generic;
 using System.Linq;
-using CodeImp.DoomBuilder.Map;
 
 #endregion
 

--- a/Source/Core/Map/MapElement3D.cs
+++ b/Source/Core/Map/MapElement3D.cs
@@ -277,7 +277,7 @@ namespace CodeImp.DoomBuilder.Map
 	{
 		public Linedef ControlLinedef { get; protected set; }
 		public Sector Sector { get; protected set; }
-		public override bool IsDisposed { get => ControlLinedef.IsDisposed || Sector.IsDisposed; }
+		public override bool IsDisposed { get => ControlLinedef.IsDisposed || Sector.IsDisposed || !General.Map.Config.GetLinedefActionInfo(ControlLinedef.Action).IsExtraFloor; }
 
 		protected ThreeDFloorSurface3D(Linedef controllinedef, Sector sidedef)
 		{
@@ -334,7 +334,7 @@ namespace CodeImp.DoomBuilder.Map
 	{
 		public Linedef ControlLinedef { get; protected set; }
 		public Sidedef Sidedef { get; protected set; }
-		public override bool IsDisposed { get => ControlLinedef.IsDisposed || Sidedef.IsDisposed; }
+		public override bool IsDisposed { get => ControlLinedef.IsDisposed || Sidedef.IsDisposed || !General.Map.Config.GetLinedefActionInfo(ControlLinedef.Action).IsExtraFloor; }
 
 		public ThreeDFloorSide3D(Linedef controllinedef, Sidedef sidedef)
 		{
@@ -380,7 +380,7 @@ namespace CodeImp.DoomBuilder.Map
 	{
 		public Sidedef Sidedef { get; protected set; }
 		public override Sector Sector { get => Sidedef.Sector; protected set => Sector = value; }
-		public override bool IsDisposed { get => Sidedef.IsDisposed || (ControlLinedef?.IsDisposed ?? false); }
+		public override bool IsDisposed => Sidedef.IsDisposed || (ControlLinedef != null && (ControlLinedef.IsDisposed || !General.Map.Config.GetLinedefActionInfo(ControlLinedef.Action).IsExtraFloor));
 
 		public SidedefSlope3D(Sidedef sidedef, bool ceiling, Linedef controllinedef = null) : base(ceiling, controllinedef)
 		{
@@ -412,7 +412,7 @@ namespace CodeImp.DoomBuilder.Map
 	{
 		public Vertex Vertex { get; protected set; }
 		public override Sector Sector { get; protected set; }
-		public override bool IsDisposed { get => Vertex.IsDisposed || Sector.IsDisposed || (ControlLinedef?.IsDisposed ?? false); }
+		public override bool IsDisposed => Vertex.IsDisposed || Sector.IsDisposed || (ControlLinedef != null && (ControlLinedef.IsDisposed || !General.Map.Config.GetLinedefActionInfo(ControlLinedef.Action).IsExtraFloor));
 
 		public VertexSlope3D(Vertex vertex, Sector sector, bool ceiling, Linedef controllinedef = null) : base(ceiling, controllinedef)
 		{

--- a/Source/Core/Map/MapElement3D.cs
+++ b/Source/Core/Map/MapElement3D.cs
@@ -55,7 +55,7 @@ namespace CodeImp.DoomBuilder.Map
 			else if (e is Upper3D)
 				prefix = "up";
 			else if (e is Vertex3D)
-				prefix = "vertex";
+				prefix = "vertex3d";
 			else if (e is Thing3D)
 				prefix = "thing";
 			else if (e is ThreeDFloorBottom3D)
@@ -94,7 +94,7 @@ namespace CodeImp.DoomBuilder.Map
 				return Middle3D.Deserialize(content, map);
 			else if (type == "up")
 				return Upper3D.Deserialize(content, map);
-			else if (type == "vertex")
+			else if (type == "vertex3d")
 				return Vertex3D.Deserialize(content, map);
 			else if (type == "thing")
 				return Thing3D.Deserialize(content, map);

--- a/Source/Core/Map/MapElement3D.cs
+++ b/Source/Core/Map/MapElement3D.cs
@@ -1,0 +1,448 @@
+﻿
+#region ================== Copyright (c) 2007 Pascal vd Heiden
+
+/*
+ * Copyright (c) 2007 Pascal vd Heiden, www.codeimp.com
+ * This program is released under GNU General Public License
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ */
+
+#endregion
+
+#region ================== Namespaces
+
+using System;
+using ScintillaNET;
+using System.Collections.Generic;
+using System.Linq;
+using CodeImp.DoomBuilder.Map;
+
+#endregion
+
+namespace CodeImp.DoomBuilder.Map
+{
+	public abstract class MapElement3D
+	{
+		public abstract bool IsDisposed { get; }
+
+		public abstract override bool Equals(object o);
+		public abstract override int GetHashCode();
+		public abstract string Serialize();
+
+		public static bool operator ==(MapElement3D a, MapElement3D b) => Equals(a, b);
+		public static bool operator !=(MapElement3D a, MapElement3D b) => !Equals(a, b);
+
+		protected static T ParseMapElementByString<T>(string s, ICollection<T> elements) where T : MapElement
+		{
+			if (!int.TryParse(s, out int index)) return null;
+			return (index >= 0 && index < elements.Count) ? elements.ElementAt(index) : null;
+		}
+
+		public static string Serialize(MapElement3D e)
+		{
+			string prefix;
+
+			if (e is Floor3D)
+				prefix = "floor";
+			else if (e is Ceiling3D)
+				prefix = "ceiling";
+			else if (e is Lower3D)
+				prefix = "low";
+			else if (e is Middle3D)
+				prefix = "mid";
+			else if (e is Upper3D)
+				prefix = "up";
+			else if (e is Vertex3D)
+				prefix = "vertex";
+			else if (e is Thing3D)
+				prefix = "thing";
+			else if (e is ThreeDFloorBottom3D)
+				prefix = "tdbottom";
+			else if (e is ThreeDFloorTop3D)
+				prefix = "tdtop";
+			else if (e is ThreeDFloorSide3D)
+				prefix = "tdside";
+			else if (e is SidedefSlope3D)
+				prefix = "sideslope";
+			else if (e is VertexSlope3D)
+				prefix = "vertexslope";
+			else
+				return null;
+
+			return prefix + "(" + e.Serialize() + ")";
+		}
+
+		public static MapElement3D Deserialize(string s, MapSet map)
+		{
+			s = s.Trim();
+
+			int startindex = s.IndexOf('(');
+			if (startindex < 0) return null;
+
+			string type = s.Substring(0, startindex);
+			string content = s.Substring(startindex + 1, s.Length - startindex - 1);
+
+			if (type == "floor")
+				return Floor3D.Deserialize(content, map);
+			else if (type == "ceiling")
+				return Ceiling3D.Deserialize(content, map);
+			else if (type == "low")
+				return Lower3D.Deserialize(content, map);
+			else if (type == "mid")
+				return Middle3D.Deserialize(content, map);
+			else if (type == "up")
+				return Upper3D.Deserialize(content, map);
+			else if (type == "vertex")
+				return Vertex3D.Deserialize(content, map);
+			else if (type == "thing")
+				return Thing3D.Deserialize(content, map);
+			else if (type == "tdbottom")
+				return ThreeDFloorBottom3D.Deserialize(content, map);
+			else if (type == "tdtop")
+				return ThreeDFloorTop3D.Deserialize(content, map);
+			else if (type == "tdside")
+				return ThreeDFloorSide3D.Deserialize(content, map);
+			else if (type == "sideslope")
+				return SidedefSlope3D.Deserialize(content, map);
+			else if (type == "vertexslope")
+				return VertexSlope3D.Deserialize(content, map);
+			else
+				return null;
+		}
+	}
+
+	public abstract class SectorSurface3D : MapElement3D
+	{
+		public Sector Sector { get; protected set; }
+		public override bool IsDisposed { get => Sector.IsDisposed; }
+
+		protected SectorSurface3D(Sector sector)
+		{
+			Sector = sector;
+		}
+
+		public override string Serialize() => Sector.Index.ToString();
+	}
+
+	public class Floor3D : SectorSurface3D
+	{
+		public Floor3D(Sector sector) : base(sector) { }
+
+		public override bool Equals(object o) => o is Floor3D f && Sector == f.Sector;
+		public override int GetHashCode() => Sector.GetHashCode();
+
+		public new static Floor3D Deserialize(string s, MapSet map)
+		{
+			var sector = MapElement3D.ParseMapElementByString(s, map.Sectors);
+			if (sector == null) return null;
+
+			return new Floor3D(sector);
+		}
+	}
+
+	public class Ceiling3D : SectorSurface3D
+	{
+		public Ceiling3D(Sector sector) : base(sector) { }
+
+		public override bool Equals(object o) => o is Ceiling3D c && Sector == c.Sector;
+		public override int GetHashCode() => Sector.GetHashCode();
+
+		public new static Ceiling3D Deserialize(string s, MapSet map)
+		{
+			var sector = MapElement3D.ParseMapElementByString(s, map.Sectors);
+			if (sector == null) return null;
+
+			return new Ceiling3D(sector);
+		}
+	}
+
+	public abstract class SidedefPart3D : MapElement3D
+	{
+		public Sidedef Sidedef { get; protected set; }
+		public override bool IsDisposed { get => Sidedef.IsDisposed; }
+
+		protected SidedefPart3D(Sidedef sidedef)
+		{
+			Sidedef = sidedef;
+		}
+
+		public override string Serialize() => Sidedef.Index.ToString();
+	}
+
+	public class Lower3D : SidedefPart3D {
+		public Lower3D(Sidedef sidedef) : base(sidedef) { }
+
+		public override bool Equals(object o) => o is Lower3D l && Sidedef == l.Sidedef;
+		public override int GetHashCode() => Sidedef.GetHashCode();
+
+		public new static Lower3D Deserialize(string s, MapSet map)
+		{
+			var side = MapElement3D.ParseMapElementByString(s, map.Sidedefs);
+			if (side == null) return null;
+
+			return new Lower3D(side);
+		}
+	}
+
+	public class Middle3D : SidedefPart3D {
+		public Middle3D(Sidedef sidedef) : base(sidedef) { }
+
+		public override bool Equals(object o) => o is Middle3D m && Sidedef == m.Sidedef;
+		public override int GetHashCode() => Sidedef.GetHashCode();
+
+		public new static Middle3D Deserialize(string s, MapSet map)
+		{
+			var side = MapElement3D.ParseMapElementByString(s, map.Sidedefs);
+			if (side == null) return null;
+
+			return new Middle3D(side);
+		}
+	}
+
+	public class Upper3D : SidedefPart3D {
+		public Upper3D(Sidedef sidedef) : base(sidedef) { }
+
+		public override bool Equals(object o) => o is Upper3D u && Sidedef == u.Sidedef;
+		public override int GetHashCode() => Sidedef.GetHashCode();
+
+		public new static Upper3D Deserialize(string s, MapSet map)
+		{
+			var side = MapElement3D.ParseMapElementByString(s, map.Sidedefs);
+			if (side == null) return null;
+
+			return new Upper3D(side);
+		}
+	}
+
+	public class Vertex3D : MapElement3D
+	{
+		public Vertex Vertex { get; protected set; }
+		public bool IsFloor { get => !IsCeiling; }
+		public bool IsCeiling { get; protected set; }
+		public override bool IsDisposed { get => Vertex.IsDisposed; }
+
+		public Vertex3D(Vertex vertex, bool ceiling)
+		{
+			Vertex = vertex;
+			IsCeiling = ceiling;
+		}
+
+		public override bool Equals(object o) => o is Vertex3D v && Vertex == v.Vertex && IsCeiling == v.IsCeiling;
+		public override int GetHashCode() => Vertex.GetHashCode();
+		public override string Serialize() => $"{(IsCeiling ? "c" : "f")} {Vertex.Index}";
+
+		public new static Vertex3D Deserialize(string s, MapSet map)
+		{
+			var parts = s.Split(' ');
+			if (parts.Length != 2) return null;
+
+			bool ceiling = (parts[0] == "c");
+
+			var vertex = MapElement3D.ParseMapElementByString(parts[1], map.Vertices);
+			if (vertex == null) return null;
+
+			return new Vertex3D(vertex, ceiling);
+		}
+	}
+
+	public class Thing3D : MapElement3D
+	{
+		public Thing Thing { get; protected set; }
+		public override bool IsDisposed { get => Thing.IsDisposed; }
+
+		public Thing3D(Thing vertex)
+		{
+			Thing = vertex;
+		}
+
+		public override bool Equals(object o) => o is Thing3D t && Thing == t.Thing;
+		public override int GetHashCode() => Thing.GetHashCode();
+		public override string Serialize() => Thing.Index.ToString();
+
+		public new static Thing3D Deserialize(string s, MapSet map)
+		{
+			var thing = MapElement3D.ParseMapElementByString(s, map.Things);
+			if (thing == null) return null;
+
+			return new Thing3D(thing);
+		}
+	}
+
+	public abstract class ThreeDFloorSurface3D : MapElement3D
+	{
+		public Linedef ControlLinedef { get; protected set; }
+		public Sector Sector { get; protected set; }
+		public override bool IsDisposed { get => ControlLinedef.IsDisposed || Sector.IsDisposed; }
+
+		protected ThreeDFloorSurface3D(Linedef controllinedef, Sector sidedef)
+		{
+			ControlLinedef = controllinedef;
+			Sector = sidedef;
+		}
+
+		public override string Serialize() => ControlLinedef.Index + " " + Sector.Index;
+	}
+
+	public class ThreeDFloorBottom3D : ThreeDFloorSurface3D {
+		public ThreeDFloorBottom3D(Linedef controllinedef, Sector sector) : base(controllinedef, sector) { }
+
+		public override bool Equals(object o) => o is ThreeDFloorBottom3D b && ControlLinedef == b.ControlLinedef && Sector == b.Sector;
+		public override int GetHashCode() => (ControlLinedef?.GetHashCode() ?? 0) + Sector.GetHashCode();
+
+		public new static ThreeDFloorBottom3D Deserialize(string s, MapSet map)
+		{
+			var parts = s.Split(' ');
+			if (parts.Length != 2) return null;
+
+			var controlline = MapElement3D.ParseMapElementByString(parts[0], map.Linedefs);
+			if (controlline == null && parts[0] != "-1") return null;
+
+			var sector = MapElement3D.ParseMapElementByString(parts[1], map.Sectors);
+			if (sector == null) return null;
+
+			return new ThreeDFloorBottom3D(controlline, sector);
+		}
+	}
+
+	public class ThreeDFloorTop3D : ThreeDFloorSurface3D {
+		public ThreeDFloorTop3D(Linedef controllinedef, Sector sector) : base(controllinedef, sector) { }
+
+		public override bool Equals(object o) => o is ThreeDFloorTop3D t && ControlLinedef == t.ControlLinedef && Sector == t.Sector;
+		public override int GetHashCode() => (ControlLinedef?.GetHashCode() ?? 0) + Sector.GetHashCode();
+
+		public new static ThreeDFloorTop3D Deserialize(string s, MapSet map)
+		{
+			var parts = s.Split(' ');
+			if (parts.Length != 2) return null;
+
+			var controlline = MapElement3D.ParseMapElementByString(parts[0], map.Linedefs);
+			if (controlline == null && parts[0] != "-1") return null;
+
+			var sector = MapElement3D.ParseMapElementByString(parts[1], map.Sectors);
+			if (sector == null) return null;
+
+			return new ThreeDFloorTop3D(controlline, sector);
+		}
+	}
+
+	public class ThreeDFloorSide3D : MapElement3D
+	{
+		public Linedef ControlLinedef { get; protected set; }
+		public Sidedef Sidedef { get; protected set; }
+		public override bool IsDisposed { get => ControlLinedef.IsDisposed || Sidedef.IsDisposed; }
+
+		public ThreeDFloorSide3D(Linedef controllinedef, Sidedef sidedef)
+		{
+			ControlLinedef = controllinedef;
+			Sidedef = sidedef;
+		}
+
+		public override bool Equals(object o) => o is ThreeDFloorSide3D s && ControlLinedef == s.ControlLinedef && Sidedef == s.Sidedef;
+		public override int GetHashCode() => (ControlLinedef?.GetHashCode() ?? 0) + Sidedef.GetHashCode();
+		public override string Serialize() => ControlLinedef.Index + " " + Sidedef.Index;
+
+		public new static ThreeDFloorSide3D Deserialize(string s, MapSet map)
+		{
+			var parts = s.Split(' ');
+			if (parts.Length != 2) return null;
+
+			var controlline = MapElement3D.ParseMapElementByString(parts[0], map.Linedefs);
+			if (controlline == null && parts[0] != "-1") return null;
+
+			var side = MapElement3D.ParseMapElementByString(parts[1], map.Sidedefs);
+			if (side == null) return null;
+
+			return new ThreeDFloorSide3D(controlline, side);
+		}
+	}
+
+	public abstract class Slope3D : MapElement3D
+	{
+		public Linedef ControlLinedef { get; protected set; }
+		public abstract Sector Sector { get; protected set; }
+		public bool IsFloor { get => !IsCeiling; }
+		public bool IsCeiling { get; protected set; }
+		public bool Is3DFloor { get => ControlLinedef != null; }
+
+		protected Slope3D(bool ceiling, Linedef controllinedef = null)
+		{
+			IsCeiling = ceiling;
+			ControlLinedef = controllinedef;
+		}
+	}
+
+	public class SidedefSlope3D : Slope3D
+	{
+		public Sidedef Sidedef { get; protected set; }
+		public override Sector Sector { get => Sidedef.Sector; protected set => Sector = value; }
+		public override bool IsDisposed { get => Sidedef.IsDisposed || (ControlLinedef?.IsDisposed ?? false); }
+
+		public SidedefSlope3D(Sidedef sidedef, bool ceiling, Linedef controllinedef = null) : base(ceiling, controllinedef)
+		{
+			Sidedef = sidedef;
+		}
+
+		public override bool Equals(object o) => o is SidedefSlope3D s && Sidedef == s.Sidedef && IsCeiling == s.IsCeiling && ControlLinedef == s.ControlLinedef;
+		public override int GetHashCode() => Sidedef.GetHashCode() + IsCeiling.GetHashCode() + (ControlLinedef?.GetHashCode() ?? 0);
+		public override string Serialize() => $"{(IsCeiling ? "c" : "f")} {Sidedef.Index} {ControlLinedef?.Index ?? -1}";
+
+		public new static SidedefSlope3D Deserialize(string s, MapSet map)
+		{
+			var parts = s.Split(' ');
+			if (parts.Length != 3) return null;
+
+			bool ceiling = (parts[0] == "c");
+
+			var side = MapElement3D.ParseMapElementByString(parts[1], map.Sidedefs);
+			if (side == null) return null;
+
+			var controlline = MapElement3D.ParseMapElementByString(parts[2], map.Linedefs);
+			if (controlline == null && parts[2] != "-1") return null;
+
+			return new SidedefSlope3D(side, ceiling, controlline);
+		}
+	}
+
+	public class VertexSlope3D : Slope3D
+	{
+		public Vertex Vertex { get; protected set; }
+		public override Sector Sector { get; protected set; }
+		public override bool IsDisposed { get => Vertex.IsDisposed || Sector.IsDisposed || (ControlLinedef?.IsDisposed ?? false); }
+
+		public VertexSlope3D(Vertex vertex, Sector sector, bool ceiling, Linedef controllinedef = null) : base(ceiling, controllinedef)
+		{
+			Vertex = vertex;
+			Sector = sector;
+		}
+
+		public override bool Equals(object o) => o is VertexSlope3D s && Vertex == s.Vertex && Sector == s.Sector && IsFloor == s.IsFloor && ControlLinedef == s.ControlLinedef;
+		public override int GetHashCode() => Vertex.GetHashCode() + IsFloor.GetHashCode() + (ControlLinedef?.GetHashCode() ?? 0);
+		public override string Serialize() => $"{(IsCeiling ? "c" : "f")} {Vertex.Index} {Sector.Index} {ControlLinedef?.Index ?? -1}";
+
+		public new static VertexSlope3D Deserialize(string s, MapSet map)
+		{
+			var parts = s.Split(' ');
+			if (parts.Length != 4) return null;
+
+			bool ceiling = (parts[0] == "c");
+
+			var vertex = MapElement3D.ParseMapElementByString(parts[1], map.Vertices);
+			if (vertex == null) return null;
+
+			var sector = MapElement3D.ParseMapElementByString(parts[2], map.Sectors);
+			if (sector == null) return null;
+
+			var controlline = MapElement3D.ParseMapElementByString(parts[3], map.Linedefs);
+			if (controlline == null && parts[3] != "-1") return null;
+
+			return new VertexSlope3D(vertex, sector, ceiling, controlline);
+		}
+	}
+
+	public class Group3D : List<MapElement3D> { }
+}

--- a/Source/Core/Map/MapElement3D.cs
+++ b/Source/Core/Map/MapElement3D.cs
@@ -230,7 +230,7 @@ namespace CodeImp.DoomBuilder.Map
 		}
 
 		public override bool Equals(object o) => o is Vertex3D v && Vertex == v.Vertex && IsCeiling == v.IsCeiling;
-		public override int GetHashCode() => Vertex.GetHashCode();
+		public override int GetHashCode() => Vertex.GetHashCode() + IsCeiling.GetHashCode();
 		public override string Serialize() => $"{(IsCeiling ? "c" : "f")} {Vertex.Index}";
 
 		public new static Vertex3D Deserialize(string s, MapSet map)

--- a/Source/Core/Map/MapOptions.cs
+++ b/Source/Core/Map/MapOptions.cs
@@ -348,6 +348,7 @@ namespace CodeImp.DoomBuilder.Map
 
 			//mxd. Save selection groups
 			General.Map.Map.WriteSelectionGroups(mapconfig);
+			General.Map.Map.WriteGroups3D(mapconfig);
 
 			//mxd. Save Tag Labels
 			if(tagLabels.Count > 0) 
@@ -588,6 +589,11 @@ namespace CodeImp.DoomBuilder.Map
 			General.Map.Map.ReadSelectionGroups(mapconfig);
 		}
 		
+		internal void ReadGroups3D()
+		{
+			General.Map.Map.ReadGroups3D(mapconfig);
+		}
+
 		// This displays the current map name
 		public override string ToString()
 		{

--- a/Source/Core/Map/MapSet.cs
+++ b/Source/Core/Map/MapSet.cs
@@ -58,6 +58,8 @@ namespace CodeImp.DoomBuilder.Map
 		//mxd
 		private const string SELECTION_GROUPS_PATH = "selectiongroups";
 		
+		private const string GROUPS3D_PATH = "groups3d";
+
 		// Handler for tag fields
 		public delegate void TagHandler<T>(MapElement element, bool actionargument, UniversalType type, ref int value, T obj);
 		
@@ -178,6 +180,10 @@ namespace CodeImp.DoomBuilder.Map
 		/// this setting to avoid exceptions
 		/// </summary>
 		public bool IsSafeToAccess { get { return issafetoaccess; } set { issafetoaccess = value; } }
+
+		public List<Group3D> Groups3D { get; set; } = new List<Group3D>();
+
+		public MultiDictionary<MapElement3D, Group3D> GroupsByMapElement3D { get; set; } = new MultiDictionary<MapElement3D, Group3D>();
 
 		#endregion
 
@@ -1608,6 +1614,103 @@ namespace CodeImp.DoomBuilder.Map
 			return result;
 		}
 		
+		internal void WriteGroups3D(Configuration cfg)
+		{
+			if (!Groups3D.Any()) return;
+
+			IDictionary groupscfg = new ListDictionary();
+
+			// Fill structure
+			for (int i = 0; i < Groups3D.Count; i++)
+			{
+				Group3D group = Groups3D[i];
+
+				List<string> elementstrings = new List<string>();
+				foreach (MapElement3D e in group)
+				{
+					var s = MapElement3D.Serialize(e);
+					if (s != null)
+						elementstrings.Add(s);
+				}
+
+				IDictionary groupcfg = new ListDictionary();
+				groupcfg.Add("elements", string.Join(" ", elementstrings.ToArray()));
+				groupscfg.Add(i, groupcfg);
+			}
+
+			// Write to config
+			cfg.WriteSetting(GROUPS3D_PATH, groupscfg);
+		}
+
+		internal void ReadGroups3D(Configuration cfg)
+		{
+			IDictionary groupscfg = cfg.ReadSetting(GROUPS3D_PATH, new Hashtable());
+
+			foreach (DictionaryEntry groupscfgentry in groupscfg)
+			{
+				// Item is a structure?
+				if (groupscfgentry.Value is IDictionary)
+				{
+					int groupnum;
+					if (!int.TryParse(groupscfgentry.Key as string, out groupnum)) continue;
+
+					IDictionary groupcfg = (IDictionary)groupscfgentry.Value;
+
+					if (groupcfg.Contains("elements"))
+					{
+						string s = groupcfg["elements"] as string;
+						if (!string.IsNullOrEmpty(s))
+						{
+							Group3D group = DeserializeGroup3D(s);
+							if (group != null)
+							{
+								Groups3D.Add(group);
+								foreach (var e in group)
+									GroupsByMapElement3D.Add(e, group);
+							}
+						}
+					}
+				}
+			}
+		}
+
+		private Group3D DeserializeGroup3D(string input)
+		{
+			string[] parts = input.Split(new[] { ')' }, StringSplitOptions.RemoveEmptyEntries);
+			Group3D group = new Group3D();
+
+			foreach (string part in parts)
+			{
+				MapElement3D element = MapElement3D.Deserialize(part, this);
+				if (element != null)
+					group.Add(element);
+			}
+
+			return group;
+		}
+
+		public bool CleanupGroup3D(Group3D group)
+		{
+			group.RemoveAll(e => {
+				if (e.IsDisposed)
+				{
+					General.Map.Map.GroupsByMapElement3D.Remove(e, group);
+					return true;
+				}
+				else
+				{
+					return false;
+				}
+			});
+
+			return !group.Any();
+		}
+
+		public void CleanupGroups3D()
+		{
+			Groups3D.RemoveAll(g => CleanupGroup3D(g));
+		}
+
 		#endregion
 
 		#region ================== Marking

--- a/Source/Plugins/BuilderModes/Resources/Actions.cfg
+++ b/Source/Plugins/BuilderModes/Resources/Actions.cfg
@@ -1573,3 +1573,33 @@ changemapelementindex
 	allowmouse = true;
 	allowscroll = false;
 }
+
+selectgroup
+{
+	title = "Group: Select";
+	category = "visual";
+	description = "Selects any groups the element belongs to. Use multiple times to cycle through groups.";
+	allowkeys = true;
+	allowmouse = true;
+	allowscroll = false;
+}
+
+creategroup
+{
+	title = "Group: Create";
+	category = "visual";
+	description = "Creates a new group from the selection.";
+	allowkeys = true;
+	allowmouse = true;
+	allowscroll = false;
+}
+
+updateordeletelastselectedgroup
+{
+	title = "Group: Update Or Delete Last Selected";
+	category = "visual";
+	description = "Updates or deletes the group that was last selected. If the selection is empty, deletes it instead.";
+	allowkeys = true;
+	allowmouse = true;
+	allowscroll = false;
+}

--- a/Source/Plugins/BuilderModes/VisualModes/BaseVisualGeometrySector.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/BaseVisualGeometrySector.cs
@@ -80,6 +80,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 		public bool Changed { get { return changed; } set { changed = value; } }
 		public SectorLevel Level { get { return level; } }
 		public Effect3DFloor ExtraFloor { get { return extrafloor; } }
+		public abstract MapElement3D AsMapElement3D { get; }
 
 		#endregion
 

--- a/Source/Plugins/BuilderModes/VisualModes/BaseVisualGeometrySidedef.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/BaseVisualGeometrySidedef.cs
@@ -225,7 +225,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 									int lightlevel;
 
 									// Sidedef part is not affected by 3d floor brightness
-									if(l.type != SectorLevelType.Light && (l.disablelighting || !l.extrafloor))
+									if(l.type != SectorLevelType.Light && (l.disablelighting || l.extrafloor == null))
 										lightlevel = (lightabsolute ? lightvalue : l.brightnessbelow + lightvalue);
 									// 3d floors and light transfer effects transfers brightness below them ignoring sidedef's brightness
 									else

--- a/Source/Plugins/BuilderModes/VisualModes/BaseVisualGeometrySidedef.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/BaseVisualGeometrySidedef.cs
@@ -73,6 +73,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 		
 		public bool IsDraggingUV { get { return uvdragging; } }
 		new public BaseVisualSector Sector { get { return (BaseVisualSector)base.Sector; } }
+		public abstract MapElement3D AsMapElement3D { get; }
 		
 		#endregion
 		

--- a/Source/Plugins/BuilderModes/VisualModes/BaseVisualMode.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/BaseVisualMode.cs
@@ -891,7 +891,75 @@ namespace CodeImp.DoomBuilder.BuilderModes
 
 			return handles;
 		}
+
+		private IVisualEventReceiver GetObjectByMapElement3D(MapElement3D element)
+		{
+			if (element.IsDisposed)
+				return null;
+			else if (element is Floor3D floor)
+				return GetBaseVisualSector(floor.Sector).Floor;
+			else if (element is Ceiling3D ceiling)
+				return GetBaseVisualSector(ceiling.Sector).Ceiling;
+			else if (element is Lower3D lower)
+				return GetBaseVisualSector(lower.Sidedef.Sector).GetSidedefParts(lower.Sidedef).lower;
+			else if (element is Upper3D upper)
+				return GetBaseVisualSector(upper.Sidedef.Sector).GetSidedefParts(upper.Sidedef).upper;
+			else if (element is Middle3D middle)
+			{
+				var parts = GetBaseVisualSector(middle.Sidedef.Sector).GetSidedefParts(middle.Sidedef);
+				if (parts.middlesingle != null)
+					return parts.middlesingle;
+				else
+					return parts.middledouble;
+			}
+			else if (element is Vertex3D vertex)
+				return GetVisualVertex(vertex.Vertex, vertex.IsFloor);
+			else if (element is Thing3D thing)
+				return GetVisualThing(thing.Thing) as BaseVisualThing;
+			else if (element is ThreeDFloorBottom3D threedfloorbottom)
+			{
+				var vs = GetBaseVisualSector(threedfloorbottom.Sector);
+				return vs.ExtraFloors.Find(f => f.ExtraFloor.Linedef == threedfloorbottom.ControlLinedef);
+			}
+			else if (element is ThreeDFloorTop3D threedfloortop)
+			{
+				var vs = GetBaseVisualSector(threedfloortop.Sector);
+				return vs.ExtraCeilings.Find(f => f.ExtraFloor.Linedef == threedfloortop.ControlLinedef);
+			}
+			else if (element is ThreeDFloorSide3D threedfloorside)
+			{
+				var vs = GetBaseVisualSector(threedfloorside.Sidedef.Sector);
+				var parts = vs.GetSidedefParts(threedfloorside.Sidedef).middle3d;
+				return parts.Find(p => p.GetControlLinedef() == threedfloorside.ControlLinedef);
+			}
+			if (element is SidedefSlope3D sideslope)
+			{
+				return sidedefslopehandles[sideslope.Sidedef.Sector]
+					?.Find(s => {
+						var ss = s as VisualSidedefSlope;
 		
+						return
+							ss.Sidedef == sideslope.Sidedef &&
+							ss.Level.extrafloor?.Linedef == sideslope.ControlLinedef &&
+							ss.Level.type == (sideslope.IsFloor ? SectorLevelType.Floor : SectorLevelType.Ceiling);
+					}) as VisualSidedefSlope;
+			}
+			else if (element is VertexSlope3D vertexslope)
+			{
+				return vertexslopehandles[vertexslope.Sector]
+					?.Find(s => {
+						var vs = s as VisualVertexSlope;
+
+						return
+							vs.Vertex == vertexslope.Vertex &&
+							vs.Level.extrafloor?.Linedef == vertexslope.ControlLinedef &&
+						vs.Level.type == (vertexslope.IsFloor ? SectorLevelType.Floor : SectorLevelType.Ceiling);
+					}) as VisualVertexSlope;
+			}
+			else
+				return null;
+		}
+
 		#endregion
 
 		#region ================== Extended Methods

--- a/Source/Plugins/BuilderModes/VisualModes/BaseVisualMode.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/BaseVisualMode.cs
@@ -168,6 +168,8 @@ namespace CodeImp.DoomBuilder.BuilderModes
 		public bool PaintSelectPressed { get { return paintselectpressed; } } // biwa
 		public Type PaintSelectType { get { return paintselecttype; } set { paintselecttype = value; } } // biwa
 		public IVisualPickable Highlighted { get { return highlighted; } } // biwa
+		public Group3D SelectedGroup3D { get; internal set; }
+		public Group3D LastSelectedGroup3D { get; internal set; }
 
 		#endregion
 		
@@ -2613,6 +2615,29 @@ namespace CodeImp.DoomBuilder.BuilderModes
 			return t;
         }
 		
+		internal List<Group3D> FindGroups3DWithObject(IVisualEventReceiver o)
+		{
+			if (General.Map.Map.GroupsByMapElement3D.ContainsKey(o.AsMapElement3D))
+			{
+				var groups = General.Map.Map.GroupsByMapElement3D[o.AsMapElement3D];
+				groups.RemoveAll(g => General.Map.Map.CleanupGroup3D(g));
+				return groups;
+			}
+			else
+			{
+				return new List<Group3D>();
+			}
+		}
+
+		public Group3D FindSelectedGroup3D()
+		{
+			return General.Map.Map.Groups3D
+				.Find(group =>
+					group.Count == selectedobjects.Count &&
+						selectedobjects.All(o => group.Contains(o.AsMapElement3D))
+				);
+		}
+
 		#endregion
 
 		#region ================== Actions
@@ -2727,6 +2752,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 		public void ClearSelection()
 		{
             ClearSelection(true, true, true, true, true, true);
+			SelectedGroup3D = null;
 		}
 
 		[BeginAction("visualselect", BaseAction = true)]
@@ -4886,6 +4912,133 @@ namespace CodeImp.DoomBuilder.BuilderModes
 				((BaseVisualThing)allthings[t]).Rebuild();
 
 				General.Interface.DisplayStatus(StatusType.Action, $"Applied camera rotation and pitch to {things.Count} thing{(things.Count == 1 ? "" : "s")}.");
+			}
+		}
+
+		[BeginAction("selectgroup")]
+		public void SelectGroup()
+		{
+			PickTargetUnlocked();
+
+			if (HighlightedTarget == null)
+			{
+				General.Interface.DisplayStatus(StatusType.Warning, "You must highlight an element to select a group.");
+				return;
+			}
+
+			var selectablegroups = FindGroups3DWithObject(HighlightedTarget as IVisualEventReceiver);
+			if (!selectablegroups.Any())
+			{
+				General.Interface.DisplayStatus(StatusType.Warning, "The highlighted element does not belong to any group.");
+				return;
+			}
+
+			var selectedgroupindex = selectablegroups.IndexOf(SelectedGroup3D);
+			var nextgroupindex = selectedgroupindex + 1;
+
+			if (selectedgroupindex >= 0)
+			{
+				foreach (var e in selectablegroups[selectedgroupindex])
+				{
+					var o = GetObjectByMapElement3D(e);
+					if (o != null && o.Selected)
+					{
+						o.OnSelectBegin();
+						o.OnSelectEnd();
+					}
+				}
+			}
+
+			if (nextgroupindex < selectablegroups.Count)
+			{
+				SelectedGroup3D = selectablegroups[nextgroupindex];
+				LastSelectedGroup3D = SelectedGroup3D;
+
+				foreach (var e in SelectedGroup3D)
+				{
+					var o = GetObjectByMapElement3D(e);
+					if (o != null && !o.Selected)
+					{
+						o.OnSelectBegin();
+						o.OnSelectEnd();
+					}
+				}
+
+				General.Interface.DisplayStatus(StatusType.Info, "Selected group " + (nextgroupindex + 1) + "/" + selectablegroups.Count + ".");
+			}
+			else
+			{
+				SelectedGroup3D = null;
+				LastSelectedGroup3D = null;
+				General.Interface.DisplayStatus(StatusType.Info, "Deselected group.");
+			}
+		}
+
+		[BeginAction("creategroup")]
+		public void CreateGroup()
+		{
+			General.Map.Map.CleanupGroups3D();
+
+			if (FindSelectedGroup3D() != null) return;
+
+			var group = new Group3D();
+
+			foreach (var o in selectedobjects)
+				if (o.AsMapElement3D != null)
+					group.Add(o.AsMapElement3D);
+
+			foreach (var e in group)
+				General.Map.Map.GroupsByMapElement3D.Add(e, group);
+
+			if (!group.Any())
+			{
+				General.Interface.DisplayStatus(StatusType.Warning, "You must select at least one element to create a group.");
+				return;
+			}
+
+			General.Map.Map.Groups3D.Add(group);
+			SelectedGroup3D = group;
+			LastSelectedGroup3D = group;
+
+			General.Interface.DisplayStatus(StatusType.Action, "Created a new group with " + group.Count + " elements.");
+		}
+
+		[BeginAction("updateordeletelastselectedgroup")]
+		public void UpdateOrDeleteLastSelectedGroup()
+		{
+			General.Map.Map.CleanupGroups3D();
+
+			if (LastSelectedGroup3D == null || !General.Map.Map.Groups3D.Contains(LastSelectedGroup3D))
+			{
+				General.Interface.DisplayStatus(StatusType.Warning, "Select a group first.");
+				return;
+			}
+
+			foreach (var e in LastSelectedGroup3D)
+				if (!e.IsDisposed)
+					General.Map.Map.GroupsByMapElement3D.Remove(e, LastSelectedGroup3D);
+			LastSelectedGroup3D.Clear();
+
+			foreach (var o in selectedobjects)
+			{
+				var e = o.AsMapElement3D;
+				if (e != null)
+				{
+					LastSelectedGroup3D.Add(e);
+					General.Map.Map.GroupsByMapElement3D.Add(e, LastSelectedGroup3D);
+				}
+			}
+
+			if (LastSelectedGroup3D.Any())
+			{
+				General.Interface.DisplayStatus(StatusType.Action, "Updated a group.");
+			}
+			else
+			{
+				General.Map.Map.Groups3D.Remove(LastSelectedGroup3D);
+				LastSelectedGroup3D = null;
+
+				General.Interface.DisplayStatus(StatusType.Action, "Deleted a group.");
 			}
 		}
 

--- a/Source/Plugins/BuilderModes/VisualModes/BaseVisualMode.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/BaseVisualMode.cs
@@ -4627,7 +4627,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 			{
 				SectorLevel level = bvgs.Level;
 				bool applytoceiling = false;
-				if (level.extrafloor)
+				if (level.extrafloor != null)
 				{
 					// The top side of 3D floors is the ceiling of the sector, but it's a "floor" in UDB, so the
 					// ceiling of the control sector has to be modified

--- a/Source/Plugins/BuilderModes/VisualModes/BaseVisualMode.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/BaseVisualMode.cs
@@ -490,6 +490,11 @@ namespace CodeImp.DoomBuilder.BuilderModes
 			return vt.Setup() ? vt : null;
 		}
 
+		internal BaseVisualSector GetBaseVisualSector(Sector s)
+		{
+			return GetVisualSector(s) as BaseVisualSector;
+		}
+
 		// This locks the target so that it isn't changed until unlocked
 		public void LockTarget()
 		{
@@ -983,7 +988,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 					if(!VisualSectorExists(s)) continue;
 
 					// The visual sector associated is now outdated
-					BaseVisualSector vs = (BaseVisualSector)GetVisualSector(s);
+					BaseVisualSector vs = GetBaseVisualSector(s);
 					vs.UpdateSectorGeometry(true);
 				}
 			}
@@ -1796,7 +1801,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 				{
 					if(sd.Marked && VisualSectorExists(sd.Sector))
 					{
-						BaseVisualSector vs = (BaseVisualSector)GetVisualSector(sd.Sector);
+						BaseVisualSector vs = GetBaseVisualSector(sd.Sector);
 						VisualSidedefParts parts = vs.GetSidedefParts(sd);
 						parts.SetupAllParts();
 					}
@@ -1817,7 +1822,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 							{
 								if(VisualSectorExists(us.Key))
 								{
-									BaseVisualSector vs = (BaseVisualSector)GetVisualSector(us.Key);
+									BaseVisualSector vs = GetBaseVisualSector(us.Key);
 									vs.UpdateSectorGeometry(us.Value);
 								}
 							}
@@ -1826,7 +1831,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 						// And update for this sector ofcourse
 						if(VisualSectorExists(s))
 						{
-							BaseVisualSector vs = (BaseVisualSector)GetVisualSector(s);
+							BaseVisualSector vs = GetBaseVisualSector(s);
 							vs.UpdateSectorGeometry(false);
 						}
 					}
@@ -2025,7 +2030,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 					{
 						if(VisualSectorExists(s.Key)) 
 						{
-							BaseVisualSector vs = (BaseVisualSector)GetVisualSector(s.Key);
+							BaseVisualSector vs = GetBaseVisualSector(s.Key);
 							vs.UpdateSectorGeometry(s.Value);
 						}
 					}
@@ -2126,7 +2131,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 							// Update control sector
 							SectorData sd = GetSectorData(bvs.Level.sector);
 							sd.Update();
-							BaseVisualSector vs = (BaseVisualSector)GetVisualSector(bvs.Level.sector);
+							BaseVisualSector vs = GetBaseVisualSector(bvs.Level.sector);
 							vs.Rebuild();
 
 							// Add to collection
@@ -2138,7 +2143,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 							{
 								if(!donesectors.Contains(other.Index))
 								{
-									BaseVisualSector vsother = (BaseVisualSector)GetVisualSector(other);
+									BaseVisualSector vsother = GetBaseVisualSector(other);
 									vsother.Rebuild();
 
 									// Add to collection
@@ -3647,7 +3652,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 					// Update the parts for this sidedef!
 					if(VisualSectorExists(sd.Sector)) 
 					{
-						BaseVisualSector vs = (BaseVisualSector)GetVisualSector(sd.Sector);
+						BaseVisualSector vs = GetBaseVisualSector(sd.Sector);
 						VisualSidedefParts parts = vs.GetSidedefParts(sd);
 						parts.SetupAllParts();
 					}
@@ -4079,7 +4084,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 						{
 							if(VisualSectorExists(s.Key))
 							{
-								BaseVisualSector vs = (BaseVisualSector)GetVisualSector(s.Key);
+								BaseVisualSector vs = GetBaseVisualSector(s.Key);
 								vs.UpdateSectorGeometry(s.Value);
 							}
 						}
@@ -4237,7 +4242,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 				{
 					if(VisualSectorExists(s.Key)) 
 					{
-						BaseVisualSector vs = (BaseVisualSector)GetVisualSector(s.Key);
+						BaseVisualSector vs = GetBaseVisualSector(s.Key);
 						vs.UpdateSectorGeometry(s.Value);
 					}
 				}
@@ -4667,7 +4672,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 				BaseVisualSector vs;
 				if (VisualSectorExists(level.sector))
 				{
-					vs = (BaseVisualSector)GetVisualSector(level.sector);
+					vs = GetBaseVisualSector(level.sector);
 				}
 				else
 				{
@@ -5088,8 +5093,8 @@ namespace CodeImp.DoomBuilder.BuilderModes
 				//mxd. Get visual parts
 				if (VisualSectorExists(j.sidedef.Sector))
 				{
-					VisualSidedefParts parts = ((BaseVisualSector)GetVisualSector(j.sidedef.Sector)).GetSidedefParts(j.sidedef);
-					//VisualSidedefParts controlparts = (j.sidedef != j.controlSide ? ((BaseVisualSector)GetVisualSector(j.controlSide.Sector)).GetSidedefParts(j.controlSide) : parts);
+					VisualSidedefParts parts = GetBaseVisualSector(j.sidedef.Sector).GetSidedefParts(j.sidedef);
+					//VisualSidedefParts controlparts = (j.sidedef != j.controlSide ? GetBaseVisualSector(j.controlSide.Sector).GetSidedefParts(j.controlSide) : parts);
 
 					matchtop = (!j.sidedef.Marked && (!singleselection || texturehashes.Contains(j.sidedef.LongHighTexture)) && (parts.upper != null && parts.upper.Triangles > 0));
 					matchbottom = (!j.sidedef.Marked && (!singleselection || texturehashes.Contains(j.sidedef.LongLowTexture)) && (parts.lower != null && parts.lower.Triangles > 0));

--- a/Source/Plugins/BuilderModes/VisualModes/BaseVisualMode.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/BaseVisualMode.cs
@@ -917,7 +917,10 @@ namespace CodeImp.DoomBuilder.BuilderModes
 			else if (element is Vertex3D vertex)
 				return GetVisualVertex(vertex.Vertex, vertex.IsFloor);
 			else if (element is Thing3D thing)
-				return GetVisualThing(thing.Thing) as BaseVisualThing;
+			{
+				VisualThing vt = !VisualThingExists(thing.Thing) ? CreateVisualThing(thing.Thing) : GetVisualThing(thing.Thing);
+				return vt as BaseVisualThing;
+			}
 			else if (element is ThreeDFloorBottom3D threedfloorbottom)
 			{
 				var vs = GetBaseVisualSector(threedfloorbottom.Sector);

--- a/Source/Plugins/BuilderModes/VisualModes/BaseVisualSlope.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/BaseVisualSlope.cs
@@ -23,6 +23,7 @@ namespace CodeImp.DoomBuilder.VisualModes
 		#region ================== Properties
 
 		public SectorLevel Level { get { return level; } }
+		public abstract MapElement3D AsMapElement3D { get; }
 
 		#endregion
 

--- a/Source/Plugins/BuilderModes/VisualModes/BaseVisualThing.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/BaseVisualThing.cs
@@ -60,11 +60,12 @@ namespace CodeImp.DoomBuilder.BuilderModes
 		#region ================== Properties
 
 		public bool Changed { get { return changed; } set { changed |= value; } }
+		public virtual MapElement3D AsMapElement3D { get => new Thing3D(Thing); }
 
 		#endregion
-		
+
 		#region ================== Constructor / Setup
-		
+
 		// Constructor
 		public BaseVisualThing(BaseVisualMode mode, Thing t) : base(t)
 		{

--- a/Source/Plugins/BuilderModes/VisualModes/BaseVisualVertex.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/BaseVisualVertex.cs
@@ -28,6 +28,12 @@ namespace CodeImp.DoomBuilder.BuilderModes
 
 		#endregion
 
+		#region ================== Properties
+
+		public virtual MapElement3D AsMapElement3D { get => new Vertex3D(vertex, ceilingVertex); }
+
+		#endregion
+
 		// Constructor
 		public BaseVisualVertex(BaseVisualMode mode, Vertex v, bool ceilingVertex)
 			: base(v, ceilingVertex) 

--- a/Source/Plugins/BuilderModes/VisualModes/Effect3DFloor.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/Effect3DFloor.cs
@@ -158,8 +158,8 @@ namespace CodeImp.DoomBuilder.BuilderModes
 			}
 
 			//mxd
-			floor.extrafloor = true;
-			ceiling.extrafloor = true;
+			floor.extrafloor = this;
+			ceiling.extrafloor = this;
 			floor.splitsides = !clipsides;
 			ceiling.splitsides = (!clipsides && !ignorebottomheight); // if "ignorebottomheight" flag is set, both ceiling and floor will be at the same level and sidedef clipping with floor level will fail resulting in incorrect light props transfer in some cases
 

--- a/Source/Plugins/BuilderModes/VisualModes/IVisualEventReceiver.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/IVisualEventReceiver.cs
@@ -17,6 +17,7 @@
 #region ================== Namespaces
 
 using System.Windows.Forms;
+using CodeImp.DoomBuilder.Map;
 
 #endregion
 

--- a/Source/Plugins/BuilderModes/VisualModes/IVisualEventReceiver.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/IVisualEventReceiver.cs
@@ -26,7 +26,8 @@ namespace CodeImp.DoomBuilder.BuilderModes
 	{
 		//mxd. Properties
 		bool Selected { get; }
-		
+		MapElement3D AsMapElement3D { get; }
+
 		// The events that must be handled
 		void OnSelectBegin();
 		void OnSelectEnd();

--- a/Source/Plugins/BuilderModes/VisualModes/NullVisualEventReceiver.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/NullVisualEventReceiver.cs
@@ -17,6 +17,7 @@
 #region ================== Namespaces
 
 using System.Windows.Forms;
+using CodeImp.DoomBuilder.Map;
 
 #endregion
 

--- a/Source/Plugins/BuilderModes/VisualModes/NullVisualEventReceiver.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/NullVisualEventReceiver.cs
@@ -26,7 +26,8 @@ namespace CodeImp.DoomBuilder.BuilderModes
 	internal class NullVisualEventReceiver : IVisualEventReceiver
 	{
 		public bool Selected { get { return false; } } //mxd
-		
+		public MapElement3D AsMapElement3D { get => null; }
+
 		public void OnSelectBegin() { }
 		public void OnSelectEnd() { }
 		public void OnEditBegin() {	}

--- a/Source/Plugins/BuilderModes/VisualModes/SectorData.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/SectorData.cs
@@ -466,7 +466,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 							if(!l.affectedbyglow) l.color = GetLevelColor(src, l);
 
 							// Transfer brightnessbelow and colorbelow if current level is not extrafloor top
-							if(!(l.extrafloor && l.type == SectorLevelType.Floor))
+							if(!(l.extrafloor != null && l.type == SectorLevelType.Floor))
 							{
 								l.brightnessbelow = src.brightnessbelow;
 								l.colorbelow = src.colorbelow;
@@ -474,7 +474,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 						}
 
 						// Store bottom extrafloor level if it doesn't have "restrictlighting" or "restrictlighting" flags set
-						if(l.extrafloor && l.type == SectorLevelType.Ceiling && !l.restrictlighting && !l.disablelighting) stored = l;
+						if(l.extrafloor != null && l.type == SectorLevelType.Ceiling && !l.restrictlighting && !l.disablelighting) stored = l;
 					}
 
 					// Reset lighting?

--- a/Source/Plugins/BuilderModes/VisualModes/SectorLevel.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/SectorLevel.cs
@@ -38,7 +38,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 		public bool restrictlighting; //mxd
 		public bool resetlighting; //mxd
 		public bool affectedbyglow; //mxd
-		public bool extrafloor; //mxd
+		public Effect3DFloor extrafloor; //mxd
 		public bool splitsides; //mxd
 		
 		// Constructor
@@ -90,8 +90,8 @@ namespace CodeImp.DoomBuilder.BuilderModes
 		{
 			switch(type)
 			{
-				case SectorLevelType.Ceiling: return (extrafloor ? "ExtraCeiling" : "Ceiling");
-				case SectorLevelType.Floor: return (extrafloor ? "ExtraFloor" : "Floor");
+				case SectorLevelType.Ceiling: return (extrafloor != null ? "ExtraCeiling" : "Ceiling");
+				case SectorLevelType.Floor: return (extrafloor != null ? "ExtraFloor" : "Floor");
 				case SectorLevelType.Glow: return "Glow Level";
 				case SectorLevelType.Light: return "Light Level (" + GetLightType() + ")";
 				default: return "Unknown Level Type!!!";

--- a/Source/Plugins/BuilderModes/VisualModes/SectorLevelComparer.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/SectorLevelComparer.cs
@@ -36,21 +36,21 @@ namespace CodeImp.DoomBuilder.BuilderModes
 				if(!xislight && ! yislight && x.lighttype == LightLevelType.UNKNOWN && y.lighttype == LightLevelType.UNKNOWN)
 				{
 					// Both are 3d floors. Push extrafloors above extraceilings
-					if(x.extrafloor && y.extrafloor)
+					if(x.extrafloor != null && y.extrafloor != null)
 					{
 						if(x.type == SectorLevelType.Floor) return (y.type == SectorLevelType.Ceiling ? 1 : 0);
 						return (y.type == SectorLevelType.Floor ? -1 : 0);
 					}
 
 					// None is 3d floor. Push ceilings above floors
-					if(!x.extrafloor && !y.extrafloor)
+					if(x.extrafloor == null && y.extrafloor == null)
 					{
 						if(x.type == SectorLevelType.Floor) return (y.type == SectorLevelType.Ceiling ? -1 : 0);
 						return (y.type == SectorLevelType.Floor ? 1 : 0);
 					}
 
 					// One is 3d floor. Push it below the regular surface if it has "disablelighting" flag, and above otherwise
-					return ((x.extrafloor && x.disablelighting) || (y.extrafloor && !y.disablelighting) ? -1 : 1);
+					return ((x.extrafloor != null && x.disablelighting) || (y.extrafloor != null && !y.disablelighting) ? -1 : 1);
 				}
 				
 				// Push light levels above floor and ceiling levels when height is the same

--- a/Source/Plugins/BuilderModes/VisualModes/SlopeArcher.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/SlopeArcher.cs
@@ -65,9 +65,9 @@ namespace CodeImp.DoomBuilder.BuilderModes
 			length = handleline.GetLength();
 
 			if (handle1.Level.type == SectorLevelType.Ceiling)
-				baseheight = handle1.Level.extrafloor ? handle1.Level.sector.FloorHeight : handle1.Level.sector.CeilHeight;
+				baseheight = handle1.Level.extrafloor != null ? handle1.Level.sector.FloorHeight : handle1.Level.sector.CeilHeight;
 			else
-				baseheight = handle1.Level.extrafloor ? handle1.Level.sector.CeilHeight : handle1.Level.sector.FloorHeight;
+				baseheight = handle1.Level.extrafloor != null ? handle1.Level.sector.CeilHeight : handle1.Level.sector.FloorHeight;
 
 			baseheightoffset = 0.0;
 		}

--- a/Source/Plugins/BuilderModes/VisualModes/VisualCeiling.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/VisualCeiling.cs
@@ -46,6 +46,17 @@ namespace CodeImp.DoomBuilder.BuilderModes
 
 		#region ================== Properties
 
+		public override MapElement3D AsMapElement3D
+		{
+			get
+			{
+				if (ExtraFloor == null)
+					return new Ceiling3D(Sector.Sector);
+				else
+					return new ThreeDFloorTop3D(ExtraFloor.Linedef, Sector.Sector);
+			}
+		}
+
 		#endregion
 
 		#region ================== Constructor / Setup

--- a/Source/Plugins/BuilderModes/VisualModes/VisualFloor.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/VisualFloor.cs
@@ -46,6 +46,17 @@ namespace CodeImp.DoomBuilder.BuilderModes
 
 		#region ================== Properties
 
+		public override MapElement3D AsMapElement3D
+		{
+			get
+			{
+				if (ExtraFloor == null)
+					return new Floor3D(Sector.Sector);
+				else
+					return new ThreeDFloorBottom3D(ExtraFloor.Linedef, Sector.Sector);
+			}
+		}
+
 		#endregion
 
 		#region ================== Constructor / Setup

--- a/Source/Plugins/BuilderModes/VisualModes/VisualFogBoundary.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/VisualFogBoundary.cs
@@ -17,6 +17,12 @@ namespace CodeImp.DoomBuilder.BuilderModes
 		#region ================== Variables
 
 		#endregion
+
+		#region ================== Properties
+
+		public override MapElement3D AsMapElement3D { get => null; }
+
+		#endregion
 		
 		#region ================== Constructor / Setup
 

--- a/Source/Plugins/BuilderModes/VisualModes/VisualLower.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/VisualLower.cs
@@ -38,10 +38,12 @@ namespace CodeImp.DoomBuilder.BuilderModes
 		#endregion
 
 		#region ================== Variables
-		
+
 		#endregion
 
 		#region ================== Properties
+
+		public override MapElement3D AsMapElement3D { get => new Lower3D(Sidedef); }
 
 		#endregion
 

--- a/Source/Plugins/BuilderModes/VisualModes/VisualMiddle3D.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/VisualMiddle3D.cs
@@ -45,6 +45,9 @@ namespace CodeImp.DoomBuilder.BuilderModes
 		
 		#region ================== Properties
 
+		public Effect3DFloor ExtraFloor { get { return extrafloor; } }
+		public override MapElement3D AsMapElement3D { get => new ThreeDFloorSide3D(GetControlLinedef(), Sidedef); }
+
 		#endregion
 		
 		#region ================== Constructor / Setup

--- a/Source/Plugins/BuilderModes/VisualModes/VisualMiddleDouble.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/VisualMiddleDouble.cs
@@ -47,6 +47,8 @@ namespace CodeImp.DoomBuilder.BuilderModes
 
 		#region ================== Properties
 
+		public override MapElement3D AsMapElement3D { get => new Middle3D(Sidedef); }
+
 		#endregion
 
 		#region ================== Constructor / Setup

--- a/Source/Plugins/BuilderModes/VisualModes/VisualMiddleSingle.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/VisualMiddleSingle.cs
@@ -36,17 +36,19 @@ namespace CodeImp.DoomBuilder.BuilderModes
 		#region ================== Constants
 
 		#endregion
-		
+
 		#region ================== Variables
 
 		#endregion
-		
+
 		#region ================== Properties
 
+		public override MapElement3D AsMapElement3D { get => new Middle3D(Sidedef); }
+
 		#endregion
-		
+
 		#region ================== Constructor / Setup
-		
+
 		// Constructor
 		public VisualMiddleSingle(BaseVisualMode mode, VisualSector vs, Sidedef s) : base(mode, vs, s)
 		{

--- a/Source/Plugins/BuilderModes/VisualModes/VisualSidedefSlope.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/VisualSidedefSlope.cs
@@ -26,6 +26,7 @@ namespace CodeImp.DoomBuilder.VisualModes
 
 		public Sidedef Sidedef { get { return sidedef; } }
 		public int NormalizedAngleDeg { get { return (sidedef.Line.AngleDeg >= 180) ? (sidedef.Line.AngleDeg - 180) : sidedef.Line.AngleDeg; } }
+		public override MapElement3D AsMapElement3D { get => new SidedefSlope3D(Sidedef, !up, Level.extrafloor?.Linedef); }
 
 		#endregion
 

--- a/Source/Plugins/BuilderModes/VisualModes/VisualSidedefSlope.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/VisualSidedefSlope.cs
@@ -121,7 +121,7 @@ namespace CodeImp.DoomBuilder.VisualModes
 
 			if (up)
 			{
-				if (level.extrafloor && level.type == SectorLevelType.Ceiling)
+				if (level.extrafloor != null && level.type == SectorLevelType.Ceiling)
 				{
 					if (sidedef.IsFront)
 						invertline = true;
@@ -134,7 +134,7 @@ namespace CodeImp.DoomBuilder.VisualModes
 			}
 			else
 			{
-				if (level.extrafloor && level.type == SectorLevelType.Floor)
+				if (level.extrafloor != null && level.type == SectorLevelType.Floor)
 				{
 					if (!sidedef.IsFront)
 						invertline = true;
@@ -225,7 +225,7 @@ namespace CodeImp.DoomBuilder.VisualModes
 			Vector2D center = new Vector2D(level.sector.BBox.X + level.sector.BBox.Width / 2,
 											   level.sector.BBox.Y + level.sector.BBox.Height / 2);
 
-			if (level.extrafloor)
+			if (level.extrafloor != null)
 			{
 				// The top side of 3D floors is the ceiling of the sector, but it's a "floor" in UDB, so the
 				// ceiling of the control sector has to be modified

--- a/Source/Plugins/BuilderModes/VisualModes/VisualUpper.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/VisualUpper.cs
@@ -43,6 +43,8 @@ namespace CodeImp.DoomBuilder.BuilderModes
 
 		#region ================== Properties
 
+		public override MapElement3D AsMapElement3D { get => new Upper3D(Sidedef); }
+
 		#endregion
 
 		#region ================== Constructor / Setup

--- a/Source/Plugins/BuilderModes/VisualModes/VisualVertexSlope.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/VisualVertexSlope.cs
@@ -52,6 +52,7 @@ namespace CodeImp.DoomBuilder.VisualModes
 
 		public Vertex Vertex { get { return vertex; } }
 		public Sector Sector { get { return sector; } }
+		public override MapElement3D AsMapElement3D { get => new VertexSlope3D(Vertex, Sector, !up, Level.extrafloor?.Linedef); }
 
 		#endregion
 


### PR DESCRIPTION
This adds support for element groups in Visual Mode.

This is a different feature from the current group system currently available in Classic Mode, which is a lot more flexible, has no arbitrary limit on the number of groups and does not require binding a new key for every possible group slot.

Groups can be made of essentially any kind of elements seen in Visual Mode, including 3D floors and slope handles.
Groups are saved in the user's .dbs file and are therefore fully persistent.

This adds three new actions:
<img width="1680" height="1002" alt="image" src="https://github.com/user-attachments/assets/eb2a0ed8-7e10-4aa1-95b3-3c26a88a4e09" />
- `Group: Create`: Creates a new group based on the current selection
- `Group: Select`: Selects any existing groups that contains the currently highlighted element; if multiple groups share that element, repeat to cycle through them
- `Group: Update Or Delete Last Selected`: Updates whatever group was selected last, or deletes it if the selection is empty

Example usage:

https://github.com/user-attachments/assets/ea5d68ca-a107-4a98-b48f-1ff628cc1ea5

https://github.com/user-attachments/assets/e15b6bc9-014f-42f2-b5a3-a456ab22139c