### PR TITLE
Support texture offset changes via mouse wheel scrolling

### DIFF
--- a/Source/Plugins/BuilderModes/Interface/PreferencesForm.Designer.cs
+++ b/Source/Plugins/BuilderModes/Interface/PreferencesForm.Designer.cs
@@ -728,7 +728,8 @@ namespace CodeImp.DoomBuilder.BuilderModes
             "Do nothing",
             "Change the ceiling height",
             "Change the floor height",
-            "Change both floor and ceiling height"});
+            "Change both floor and ceiling height",
+            "Change the texture offset"});
 			this.heightbysidedef.Location = new System.Drawing.Point(342, 19);
 			this.heightbysidedef.Name = "heightbysidedef";
 			this.heightbysidedef.Size = new System.Drawing.Size(309, 21);

--- a/Source/Plugins/BuilderModes/VisualModes/BaseVisualGeometrySidedef.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/BaseVisualGeometrySidedef.cs
@@ -966,6 +966,11 @@ namespace CodeImp.DoomBuilder.BuilderModes
 					if(!this.Sector.Floor.Changed) this.Sector.Floor.OnChangeTargetHeight(amount);
 					if(!this.Sector.Ceiling.Changed) this.Sector.Ceiling.OnChangeTargetHeight(amount);
 					break;
+
+				// Change texture offset
+				case 4:
+					OnChangeTextureOffset(0, -amount, true);
+					break;
 			}
 		}
 		


### PR DESCRIPTION
This adds an additional option to enable changing the Y-offset of the selected textures when scrolling the mouse wheel in Visual Mode.